### PR TITLE
ensure logs are not accumulated between batches

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
-		<VersionPrefix>0.0.1</VersionPrefix>
+		<VersionPrefix>0.0.2</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/GrpcExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/GrpcExporter.cs
@@ -1,0 +1,59 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Grpc.Net.Client;
+using OpenTelemetry.Proto.Collector.Logs.V1;
+
+namespace Serilog.Sinks.OpenTelemetry;
+
+/// <summary>
+/// Implements an IExporter that sends OpenTelemetry Log requests
+/// over gRPC.
+/// </summary>
+public class GrpcExporter : IExporter
+{
+    readonly LogsService.LogsServiceClient _client;
+
+    readonly GrpcChannel _channel;
+
+    /// <summary>
+    /// Creates a new instance of a GrpcExporter that writes an 
+    /// ExportLogsServiceRequest to a gRPC endpoint.
+    /// </summary>
+    /// <param name="endpoint">
+    /// The full OTLP endpoint to which logs are sent. 
+    /// </param>
+    public GrpcExporter(string endpoint)
+    {
+        _channel = GrpcChannel.ForAddress(endpoint);
+        _client = new LogsService.LogsServiceClient(_channel);
+    }
+
+    /// <summary>
+    /// Frees the gRPC channel used to send logs to the OTLP endpoint.
+    /// </summary>
+    public void Dispose()
+    {
+        _channel.Dispose();
+    }
+ 
+    /// <summary>
+    /// Transforms and sends the given batch of LogEvent objects
+    /// to an OTLP endpoint.
+    /// </summary>
+    void IExporter.Export(ExportLogsServiceRequest request)
+    {
+        _client.Export(request); // FIXME: Ignores response.
+    }
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IExporter.cs
@@ -1,0 +1,19 @@
+// Copyright 2023 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenTelemetry.Proto.Collector.Logs.V1;
+
+internal interface IExporter : IDisposable {
+    void Export(ExportLogsServiceRequest request);
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
@@ -1,0 +1,101 @@
+// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Logs.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using System.Reflection;
+
+namespace Serilog.Sinks.OpenTelemetry;
+
+internal static class OpenTelemetryUtils
+{
+    internal static string? GetScopeName()
+    {
+        return Assembly.GetExecutingAssembly().GetName().Name;
+    }
+
+    internal static string? GetScopeVersion()
+    {
+        return Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+    }
+
+    internal static InstrumentationScope CreateInstrumentationScope()
+    {
+        var scope = new InstrumentationScope();
+
+        var scopeName = OpenTelemetryUtils.GetScopeName();
+        if (scopeName != null)
+        {
+            scope.Name = scopeName;
+        }
+
+        var scopeVersion = OpenTelemetryUtils.GetScopeVersion();
+        if (scopeVersion != null)
+        {
+            scope.Version = scopeVersion;
+        }
+
+        return scope;
+    }
+
+    internal static ResourceLogs CreateResourceLogs(IDictionary<string, Object>? resourceAttributes)
+    {
+        var resourceLogs = new ResourceLogs();
+
+        var attrs = Convert.ToResourceAttributes(resourceAttributes);
+        if (attrs != null)
+        {
+            var resource = new Resource();
+            resource.Attributes.AddRange(attrs);
+            resourceLogs.Resource = resource;
+            resourceLogs.SchemaUrl = Convert.SCHEMA_URL;
+        }
+
+        return resourceLogs;
+    }
+
+    internal static ScopeLogs CreateEmptyScopeLogs()
+    {
+        var scopeLogs = new ScopeLogs();
+        scopeLogs.Scope = CreateInstrumentationScope();
+        scopeLogs.SchemaUrl = Convert.SCHEMA_URL;
+
+        return scopeLogs;
+    }
+
+    internal static ExportLogsServiceRequest CreateRequestTemplate(IDictionary<string, Object>? resourceAttributes)
+    {
+        var scopeTemplate = CreateInstrumentationScope();
+
+        var resourceLogs = CreateResourceLogs(resourceAttributes);
+        resourceLogs.ScopeLogs.Add(CreateEmptyScopeLogs());
+
+        var request = new ExportLogsServiceRequest();
+        request.ResourceLogs.Add(resourceLogs);
+
+        return request;
+    }
+
+    internal static void Add(ExportLogsServiceRequest request, LogRecord logRecord)
+    {
+        try
+        {
+            request.ResourceLogs.ElementAt(0).ScopeLogs.ElementAt(0).LogRecords.Add(logRecord);
+        }
+        catch (Exception) { }
+    }
+
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
@@ -22,17 +22,17 @@ namespace Serilog.Sinks.OpenTelemetry;
 
 internal static class OpenTelemetryUtils
 {
-    internal static string? GetScopeName()
+    static string? GetScopeName()
     {
         return Assembly.GetExecutingAssembly().GetName().Name;
     }
 
-    internal static string? GetScopeVersion()
+    static string? GetScopeVersion()
     {
         return Assembly.GetExecutingAssembly().GetName().Version?.ToString();
     }
 
-    internal static InstrumentationScope CreateInstrumentationScope()
+    static InstrumentationScope CreateInstrumentationScope()
     {
         var scope = new InstrumentationScope();
 
@@ -51,7 +51,7 @@ internal static class OpenTelemetryUtils
         return scope;
     }
 
-    internal static ResourceLogs CreateResourceLogs(IDictionary<string, Object>? resourceAttributes)
+    static ResourceLogs CreateResourceLogs(IDictionary<string, Object>? resourceAttributes)
     {
         var resourceLogs = new ResourceLogs();
 
@@ -67,7 +67,7 @@ internal static class OpenTelemetryUtils
         return resourceLogs;
     }
 
-    internal static ScopeLogs CreateEmptyScopeLogs()
+    static ScopeLogs CreateEmptyScopeLogs()
     {
         var scopeLogs = new ScopeLogs();
         scopeLogs.Scope = CreateInstrumentationScope();

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryUtils.cs
@@ -97,5 +97,4 @@ internal static class OpenTelemetryUtils
         }
         catch (Exception) { }
     }
-
 }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Serilog.Sinks.OpenTelemetry.Tests;
+
+public class OpenTelemetryUtilsTests
+{
+    [Fact]
+    // Ensure that logs are not carried over from one clone of the 
+    // request template to another.
+    public void TestNoDuplicateLogs()
+    {
+        var logEvent = TestUtils.CreateLogEvent();
+        var logRecord = Convert.ToLogRecord(logEvent, "");
+
+        var requestTemplate = OpenTelemetryUtils.CreateRequestTemplate(null);
+
+        var request = requestTemplate.Clone();
+
+        var n = request.ResourceLogs.ElementAt(0).ScopeLogs.ElementAt(0).LogRecords.Count();
+        Assert.Equal(0, n);
+
+        OpenTelemetryUtils.Add(request, logRecord);
+
+        n = request.ResourceLogs.ElementAt(0).ScopeLogs.ElementAt(0).LogRecords.Count();
+        Assert.Equal(1, n);
+
+        request = requestTemplate.Clone();
+        n = request.ResourceLogs.ElementAt(0).ScopeLogs.ElementAt(0).LogRecords.Count();
+
+        Assert.Equal(0, n);
+    }
+
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
@@ -43,5 +43,4 @@ public class OpenTelemetryUtilsTests
 
         Assert.Equal(0, n);
     }
-
 }


### PR DESCRIPTION
The original implementation accumulated logs between batches because the underlying request template was modified. Ensure that an empty clone of the template is used for each batch.

Also define and use an interface for the exporter. There will soon be multiple exporters and the interaction with them requires an abstract interface.
