### PR TITLE
extract exception handling to enricher (fixes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ transformed logs to a local OpenTelemetry (OTLP/gRPC) endpoint.
 A more complete configuration would specify the `endpoint` and
 `resourceAttributes` (see below). 
 
-## Endpoint
+### Endpoint
 
 The default endpoint is `http://localhost:4317/v1/logs`, which will send
 logs to an OpenTelemetry collector running on the same machine.
@@ -47,7 +47,7 @@ In most production scenarios, you will want to set an endpoint. To do so,
 add the `endpoint` argument to the `WriteTo.OpenTelemetry()` call. This
 must be a full URL to an OTLP/gRPC endpoint. 
 
-## Resource Attributes
+### Resource Attributes
 
 OpenTelemetry logs may contain a "resource" that provides metadata concerning
 the entity associated with the logs, typically a service or library. These
@@ -92,9 +92,6 @@ MessageTemplate | Attribute[`serilog.message.template`] | |
 MessageTemplate (hash) | Attribute[`serilog.message.hash`] | | 
 Level | Field[`SeverityText`] | Direct copy of value |
 Level | Field[`SeverityNumber`] | Serilog levels mapped into corresponding OpenTelemetry levels | 
-Exception | Attribute[`exception.type`] | Value of `ex.GetType()` |
-Exception | Attribute[`exception.message`] | Value of `ex.Message`, if not empty |
-Exception | Attribute[`exception.stacktrace`] | Value of `ex.StackTrace`, if not empty |
 
 ## Trace Context Enrichment
 
@@ -128,10 +125,10 @@ This sink provides a simple enricher that will add exception information
 to the Serilog LogEvent, that conforms to the OpenTelemetry semantic 
 conventions.
 
-> :warning: As an alternative you may want to use the 
+> :warning: As an alternative, you may want to use the 
 > [Serilog.Exceptions enricher](https://github.com/RehanSaeed/Serilog.Exceptions).
 > This provides more detailed and granular information than
-> this enricher.
+> this one.
 
 If the `WithOpenTelemetryException` enricher is enabled the type, message,
 and stack trace are extracted and added as separate properties.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Serilog.Sinks.OpenTelemetry [![Build status](https://ci.appveyor.com/api/projects/status/sqmrvw34pcuatwl5/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-opentelemetry/branch/dev)
 
-:warning: Prototype implementation. Do not use for production!
+> :warning: Prototype implementation. Do not use for production!
 
 This Serilog sink will transform Serilog events into OpenTelemetry
 LogRecords and send them to an OpenTelemetry gRPC endpoint.
 
-OpenTelemetry attributes allow full support for scalar values, arrays,
-and maps. Serilog does as well. Consequently, the sink does a
-one-to-one mapping between Serilog properties and OpenTelemetry
-attributes. There is no flattening, renaming, or other modifications
-done to the properies by default.
+OpenTelemetry attributes support for scalar values, arrays, and maps.
+Serilog does as well. Consequently, the sink does a one-to-one
+mapping between Serilog properties and OpenTelemetry attributes.
+There is no flattening, renaming, or other modifications done to the
+properies by default.
 
 The formatter renders the log message, which is then stored as the
 body of the OpenTelemetry LogRecord.
 
 ## Getting Started
 
-To use the console sink, first install the [NuGet package](https://nuget.org/packages/serilog.sinks.opentelemetry):
+To use the OpenTelemetry sink, first install the [NuGet package](https://nuget.org/packages/serilog.sinks.opentelemetry):
 
 ```shell
 dotnet add package Serilog.Sinks.OpenTelemetry
@@ -32,19 +32,16 @@ var log = new LoggerConfiguration()
 
 Then use the `Log.Information(...)` and similar methods to send 
 transformed logs to a local OpenTelemetry (OTLP/gRPC) endpoint.
-The default endpoint is "http://localhost:4317". 
 
 A more complete configuration would specify the `endpoint` and
-`resourceAttributes`. 
-
-where the endpoint and resource attributes (see below) are specified.
+`resourceAttributes` (see below). 
 
 ## Endpoint
 
-The default endpoint is `http://localhost:4317`. This is appropriate for
-sending logs to an OpenTelemetry collector running on the same machine.
-This is appropriate for testing or using a local OpenTelemetry collector
-as a proxy for a downstream logging service.
+The default endpoint is `http://localhost:4317/v1/logs`, which will send
+logs to an OpenTelemetry collector running on the same machine.
+This is appropriate for testing or for using a local OpenTelemetry
+collector as a proxy for a downstream logging service.
 
 In most production scenarios, you will want to set an endpoint. To do so,
 add the `endpoint` argument to the `WriteTo.OpenTelemetry()` call. This
@@ -59,10 +56,10 @@ the configured logger.
 
 These resource attributes may be provided as a `Dictionary<string, Object>`
 when configuring a logger. While OpenTelemetry allows resource attributes
-with rich values; however, this implementation _only_ supports resource 
+with rich values, this implementation _only_ supports resource 
 attributes with primitive values. 
 
-:warning: Resource attributes with non-primitive values will be silently
+> :warning: Resource attributes with non-primitive values will be silently
 ignored.
 
 This example shows how the resource attributes can be specified when
@@ -71,7 +68,7 @@ the logger is configured.
 ```csharp
 var log = new LoggerConfiguration()
     .MinimumLevel.Information()
-    .WriteTo.OpenTelemetry(endpoint: "http://127.0.0.1:4317",
+    .WriteTo.OpenTelemetry(endpoint: "http://127.0.0.1:4317/v1/logs",
     resourceAttributes: new Dictionary<String, Object>() {
             {"service.name", "test-logging-service"},
             {"index", 10},
@@ -99,9 +96,6 @@ Exception | Attribute[`exception.type`] | Value of `ex.GetType()` |
 Exception | Attribute[`exception.message`] | Value of `ex.Message`, if not empty |
 Exception | Attribute[`exception.stacktrace`] | Value of `ex.StackTrace`, if not empty |
 
-In addition, this sink will also pull information out of the current
-Activity, if it exists.
-
 ## Trace Context Enrichment
 
 OpenTelemetry allows a TraceID and SpanID to be added to log records to 
@@ -110,7 +104,8 @@ found in the current activity.
 
 If the `WithTraceIdAndSpanId` enricher is enabled and if the logging 
 call takes place within an activity, the trace ID and span ID will 
-be extracted from the activity and added to the OpenTelemetry log record.
+be extracted from the activity and added to the Serilog LogEvent
+properties (and then into the OpenTelemetry LogRecord).
 
 ```csharp
 var log = new LoggerConfiguration()
@@ -126,6 +121,33 @@ SpanId | spanId | Field[`spanID`] | Direct binary conversion maintains fidelity 
 
 Although designed to be used with the OpenTelemetry sink, the enricher
 may be also useful when using other sinks.
+
+## Exception Enrichment
+
+This sink provides a simple enricher that will add exception information
+to the Serilog LogEvent, that conforms to the OpenTelemetry semantic 
+conventions.
+
+> :warning: As an alternative you may want to use the 
+> [Serilog.Exceptions enricher](https://github.com/RehanSaeed/Serilog.Exceptions).
+> This provides more detailed and granular information than
+> this enricher.
+
+If the `WithOpenTelemetryException` enricher is enabled the type, message,
+and stack trace are extracted and added as separate properties.
+
+```csharp
+var log = new LoggerConfiguration()
+    .Enrich.WithOpenTelemetryException()
+    .WriteTo.OpenTelemetry()
+    .CreateLogger();
+```
+
+Serilog (LogEvent) | OpenTelemetry (LogRecord) | Comment |
+--- | --- | --- | 
+Exception | Attribute[`exception.type`] | Value of `ex.GetType()` |
+Exception | Attribute[`exception.message`] | Value of `ex.Message`, if not empty |
+Exception | Attribute[`exception.stacktrace`] | Value of `ex.StackTrace`, if not empty |
 
 ## Example
 

--- a/src/Serilog.Sinks.OpenTelemetry/ExceptionLoggerExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/ExceptionLoggerExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Configuration;
+using Serilog.Sinks.OpenTelemetry;
+
+namespace Serilog;
+
+/// <summary>
+/// Class containing extension methods to <see cref="LoggerConfiguration"/>, configuring an
+/// enricher that extracts exception information and puts this into 
+/// properties that conform to the OpenTelemetry semantic conventions. 
+/// </summary>
+public static class OpenTelemetryExceptionLoggerConfigurationExtensions
+{
+    /// <summary>
+    /// If the Serilog LogEvent contains an exception, then the 
+    /// `exception.type`, `exception.message`, and `exception.stacktrace`
+    /// properties will be added (if the values are not empty).
+    ///
+    /// This enricher is designed to work with the OpenTelemetry sink.
+    /// </summary>
+    /// <returns>Logger configuration, allowing configuration to continue.</returns>
+    public static LoggerConfiguration WithOpenTelemetryException(
+        this LoggerEnrichmentConfiguration enrichConfiguration)
+    {
+        if (enrichConfiguration == null) throw new ArgumentNullException(nameof(enrichConfiguration));
+
+        return enrichConfiguration.With<ExceptionEnricher>();
+    }
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
-		<VersionPrefix>0.0.2</VersionPrefix>
+		<VersionPrefix>0.0.3</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Convert.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Convert.cs
@@ -56,7 +56,6 @@ internal static class Convert
         ProcessMessage(logRecord, renderedMessage);
         ProcessMessageTemplate(logRecord, logEvent);
         ProcessLevel(logRecord, logEvent);
-        ProcessException(logRecord, logEvent);
 
         return logRecord;
     }
@@ -130,24 +129,4 @@ internal static class Convert
         logRecord.TimeUnixNano = ConvertUtils.ToUnixNano(logEvent.Timestamp);
     }
 
-    internal static void ProcessException(LogRecord logRecord, LogEvent logEvent)
-    {
-        var ex = logEvent.Exception;
-        if (ex != null)
-        {
-            var attrs = logRecord.Attributes;
-
-            attrs.Add(ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionType, ex.GetType().ToString()));
-
-            if (ex.Message != "")
-            {
-                attrs.Add(ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionMessage, ex.Message));
-            }
-
-            if (ex.StackTrace != null && ex.StackTrace != "")
-            {
-                attrs.Add(ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionStacktrace, ex.StackTrace));
-            }
-        }
-    }
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ExceptionEnricher.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ExceptionEnricher.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenTelemetry.Trace;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.OpenTelemetry;
+
+/// <summary>
+/// This class implements the ILogEventEnricher interface for 
+/// Serilog enrichers. If there is an exception in the LogEvent
+/// then the enricher will extract the exception type, message,
+/// and stacktrace (as available) and put these into the 
+/// properties `exception.type`, `exception.message`, and 
+/// `exception.stacktrace` properties from the OpenTelemetry
+/// semantic conventions.
+/// </summary>
+public class ExceptionEnricher : ILogEventEnricher
+{
+    /// <summary>
+    /// Creates a new ExceptionEnricher instance.
+    /// </summary>
+    public ExceptionEnricher() { }
+
+    /// <summary>
+    /// Implements the `ILogEventEnricher` interface, adding `exception.type`,
+    /// `exception.message`, and `exception.stacktrace` properties. Properties
+    /// are added only if the values are not null and not the empty string.
+    /// </summary>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var ex = logEvent.Exception;
+        AddProperty(logEvent, propertyFactory, TraceSemanticConventions.AttributeExceptionType, ex?.GetType().ToString());
+        AddProperty(logEvent, propertyFactory, TraceSemanticConventions.AttributeExceptionMessage, ex?.Message);
+        AddProperty(logEvent, propertyFactory, TraceSemanticConventions.AttributeExceptionStacktrace, ex?.StackTrace);
+    }
+
+    void AddProperty(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, string propertyName, string? value)
+    {
+        if (value != null && value != "")
+        {
+            logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty(propertyName, value));
+        }
+    }
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
@@ -38,6 +38,7 @@ class Program
         var log = new LoggerConfiguration()
             .MinimumLevel.Information()
             .Enrich.WithTraceIdAndSpanId()
+            .Enrich.WithOpenTelemetryException()
             .WriteTo.OpenTelemetry(
                 endpoint: "http://127.0.0.1:4317/v1/logs",
                 resourceAttributes: new Dictionary<String, Object>() {
@@ -59,7 +60,12 @@ class Program
                 var elapsedMs = rand.Next(0, 101);
 
                 log.Information("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
-                log.Error("count = {@Count}", i);
+
+                try {
+                    throw new Exception("iteration #" + i);
+                } catch (Exception ex) {
+                    log.Error(ex, "count = {@Count}", i);
+                }
 
                 Console.WriteLine(i);
                 Thread.Sleep(1000);

--- a/test/Serilog.Sinks.OpenTelemetry.Example/README.md
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/README.md
@@ -16,21 +16,21 @@ within it. The Kubernetes CLI `kubectl` must also be available.
 
 ### Manifests
 
-- `collector-configmap.yaml`: Contains the OpenTelemetry collector
+- `k8s/collector-configmap.yaml`: Contains the OpenTelemetry collector
   configuration. It will listen on the standard OTLP gRPC and HTTP
   ports and write all received logs to the container's stdout.
 
-- `collector-deployment.yaml`: Contains the deployment
+- `k8s/collector-deployment.yaml`: Contains the deployment
   description. This deploys the standard OpenTelemetry Contrib image,
   using the given configmap as for the configuration.
 
 ### Starting Collector
 
-From this repository, run the command `kubectl apply -f .`. You should
-see two resources created. One should be a pod with a name starting
-with "collector".
+From the `k8s` subdirectory, run the command `kubectl apply -f .`. You
+should see two resources created. One should be a pod with a name
+starting with "collector".
 
-To make the necessary port visible on your local machine, forward the
+To make the **port visible on your local machine**, forward the
 port with this command:
 
 ```sh
@@ -58,8 +58,8 @@ kubectl logs -f collector-...
 ```
 
 Replace the "collector-..." with the actual pod name on your machine.
-You can find this with `kubectl get pods`. You should see one log
-each time you run the program. It should look something like:
+You can find this with `kubectl get pods`. You should see logs sent
+every few seconds. They should look similar to the following example.
 
 ```
 2022-12-11T17:20:48.537Z	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "#logs": 1}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/ConvertTest.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/ConvertTest.cs
@@ -114,36 +114,4 @@ public class ConvertTest
         Assert.Equal(nowNano, logRecord.TimeUnixNano);
     }
 
-    [Fact]
-    public void TestException()
-    {
-        var error = new Exception("error_message");
-
-        try
-        {
-            throw error;
-        }
-        catch (Exception ex)
-        {
-            var logRecord = new LogRecord();
-            var logEvent = TestUtils.CreateLogEvent(ex: ex);
-
-            Convert.ProcessException(logRecord, logEvent);
-
-            var typeKeyValue = ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionType, error.GetType().ToString());
-            var messageKeyValue = ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionMessage, error.Message);
-
-            Assert.Equal(3, logRecord.Attributes.Count);
-            Assert.NotEqual(-1, logRecord.Attributes.IndexOf(typeKeyValue));
-            Assert.NotEqual(-1, logRecord.Attributes.IndexOf(messageKeyValue));
-
-            Assert.NotNull(ex.StackTrace);
-            if (ex.StackTrace != null)
-            {
-                var traceKeyValue = ConvertUtils.NewStringAttribute(TraceSemanticConventions.AttributeExceptionStacktrace, ex.StackTrace);
-                Assert.NotEqual(-1, logRecord.Attributes.IndexOf(traceKeyValue));
-            }
-        }
-    }
-
 }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/ExceptionEnricherTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/ExceptionEnricherTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OpenTelemetry.Trace;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Sinks.OpenTelemetry.Tests;
+
+public class ExceptionEnricherTests
+{
+    [Fact]
+    public void TestNoException()
+    {
+        var enricher = new ExceptionEnricher();
+        var factory = new StringPropertyFactory();
+
+        var logEvent = TestUtils.CreateLogEvent();
+
+        enricher.Enrich(logEvent, factory);
+
+        Assert.Equal(0, logEvent.Properties.Count);
+    }
+
+    [Fact]
+    public void TestOnlyType()
+    {
+        var enricher = new ExceptionEnricher();
+        var factory = new StringPropertyFactory();
+
+        var error = new Exception("");
+        var logEvent = TestUtils.CreateLogEvent(ex: error);
+
+        enricher.Enrich(logEvent, factory);
+
+        var expectedType = CreateKvPair(TraceSemanticConventions.AttributeExceptionType, error.GetType().ToString());
+
+        Assert.Equal(1, logEvent.Properties.Count);
+        Assert.Contains(expectedType, logEvent.Properties);
+    }
+
+    [Fact]
+    public void TestTypeAndMessage()
+    {
+        var enricher = new ExceptionEnricher();
+        var factory = new StringPropertyFactory();
+
+        var error = new Exception("error_message");
+        var logEvent = TestUtils.CreateLogEvent(ex: error);
+
+        enricher.Enrich(logEvent, factory);
+
+        var expectedType = CreateKvPair(TraceSemanticConventions.AttributeExceptionType, error.GetType().ToString());
+        var expectedMessage = CreateKvPair(TraceSemanticConventions.AttributeExceptionMessage, error.Message);
+
+        Assert.Equal(2, logEvent.Properties.Count);
+        Assert.Contains(expectedType, logEvent.Properties);
+        Assert.Contains(expectedMessage, logEvent.Properties);
+    }
+
+    [Fact]
+    public void TestExceptionEnrichment()
+    {
+        var error = new Exception("error_message");
+
+        var enricher = new ExceptionEnricher();
+        var factory = new StringPropertyFactory();
+
+        try
+        {
+            throw error;
+        }
+        catch (Exception ex)
+        {
+            var logEvent = TestUtils.CreateLogEvent(ex: ex);
+
+            enricher.Enrich(logEvent, factory);
+
+            var expectedType = CreateKvPair(TraceSemanticConventions.AttributeExceptionType, error.GetType().ToString());
+            var expectedMessage = CreateKvPair(TraceSemanticConventions.AttributeExceptionMessage, error.Message);
+
+            Assert.Equal(3, logEvent.Properties.Count);
+            Assert.Contains(expectedType, logEvent.Properties);
+            Assert.Contains(expectedMessage, logEvent.Properties);
+
+            Assert.NotNull(ex.StackTrace);
+            if (ex.StackTrace != null)
+            {
+                var expectedStacktrace = CreateKvPair(TraceSemanticConventions.AttributeExceptionStacktrace, ex.StackTrace);
+                Assert.Contains(expectedStacktrace, logEvent.Properties);
+            }
+        }
+    }
+
+    KeyValuePair<string, LogEventPropertyValue> CreateKvPair(string k, string v)
+    {
+        return new KeyValuePair<string, LogEventPropertyValue>(k, new ScalarValue(v));
+    }
+
+}


### PR DESCRIPTION
Pulls the exception handling that creates attributes consistent with the OpenTelemetry semantic conventions into a separate enricher. This allows the user to choose to do nothing with the exceptions, map them into the `exception.*` OpenTelemetry attributes, or choose another solution (e.g. [Serilog.Exceptions](https://github.com/RehanSaeed/Serilog.Exceptions)).
The documentation, examples, etc. have been updated accordingly.