### PR TITLE
allow headers to be set for authorization or other purposes

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -42,6 +42,9 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// values: integers, doubles, strings, or booleans. Other values will be 
     /// silently ignored. 
     /// </param>
+    /// <param name="headers">
+    /// A Dictionary&lt;string, string&gt; containing request headers. 
+    /// </param>
     /// <param name="formatProvider">
     /// Provider for formatting and rendering log messages.
     /// </param>
@@ -63,6 +66,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         this LoggerSinkConfiguration sinkConfiguration,
         string endpoint = "http://localhost:4317/v1/logs",
         IDictionary<string, Object>? resourceAttributes = null,
+        IDictionary<string, string>? headers = null,
         IFormatProvider? formatProvider = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         int batchSizeLimit = 100,
@@ -74,7 +78,8 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         var sink = new OpenTelemetrySink(
             endpoint: endpoint,
             formatProvider: formatProvider,
-            resourceAttributes: resourceAttributes);
+            resourceAttributes: resourceAttributes,
+            headers: headers);
 
         var batchingOptions = new PeriodicBatchingSinkOptions
         {

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -46,12 +46,17 @@ public class OpenTelemetrySink : IBatchedLogEventSink, IDisposable
     /// to be used as resource attributes. Non-scalar values are silently
     /// ignored.
     /// </param>
+    /// <param name="headers">
+    /// An IDictionary&lt;string, string&gt; containing the key-value pairs
+    /// to be used as request headers.
+    /// </param>
     public OpenTelemetrySink(
        string endpoint,
        IFormatProvider? formatProvider,
-       IDictionary<string, Object>? resourceAttributes)
+       IDictionary<string, Object>? resourceAttributes,
+       IDictionary<string, string>? headers)
     {
-        _exporter = new GrpcExporter(endpoint);
+        _exporter = new GrpcExporter(endpoint, headers);
 
         _formatProvider = formatProvider;
 

--- a/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
@@ -40,11 +40,14 @@ class Program
             .Enrich.WithTraceIdAndSpanId()
             .WriteTo.OpenTelemetry(
                 endpoint: "http://127.0.0.1:4317/v1/logs",
-                resourceAttributes: new Dictionary<String, Object>() {
+                resourceAttributes: new Dictionary<string, Object>() {
                         {"service.name", "test-logging-service"},
                         {"index", 10},
                         {"flag", true},
                         {"value", 3.14}
+                },
+                headers: new Dictionary<string, string>() {
+                    {"Authorization", "Basic dXNlcjphYmMxMjM="},
                 },
                 batchSizeLimit: 2,
                 batchPeriod: 5,

--- a/test/Serilog.Sinks.OpenTelemetry.Example/README.md
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/README.md
@@ -18,7 +18,9 @@ within it. The Kubernetes CLI `kubectl` must also be available.
 
 - `collector-configmap.yaml`: Contains the OpenTelemetry collector
   configuration. It will listen on the standard OTLP gRPC and HTTP
-  ports and write all received logs to the container's stdout.
+  ports and write all received logs to the container's stdout. **The
+  collector is configured for basic authentication.** The username
+  and password are "user" and "abc123", respectively.
 
 - `collector-deployment.yaml`: Contains the deployment
   description. This deploys the standard OpenTelemetry Contrib image,
@@ -50,8 +52,10 @@ delete -f .` from the same directory where you started it.
 ## Running the Program
 
 From this subdirectory, just run the command `dotnet run`. It should
-start and then send a log to the collector. To see the log on the 
-collector, tail the collector logs:
+start and then send logs to the collector. The program adds the 
+"Authorization" header using the basic authentication scheme.
+
+To see the log on the collector, tail the collector logs:
 
 ```sh
 kubectl logs -f collector-...

--- a/test/Serilog.Sinks.OpenTelemetry.Example/k8s/collector-config.yaml
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/k8s/collector-config.yaml
@@ -6,11 +6,21 @@ metadata:
     application: collector
 data:
   config.yaml: |
+    extensions:
+      basicauth/server:
+        htpasswd:
+          inline: |
+            user:abc123
+
     receivers:
       otlp:
         protocols:
           grpc:
+            auth:
+              authenticator: basicauth/server
           http:
+            auth:
+              authenticator: basicauth/server
 
     exporters:
       logging:
@@ -19,9 +29,9 @@ data:
         sampling_thereafter: 1
 
     service:
+      extensions: [basicauth/server]
       telemetry:
         logs:
-          #encoding: json
           level: info
         metrics:
           level: none

--- a/test/Serilog.Sinks.OpenTelemetry.Example/k8s/collector-deployment.yaml
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/k8s/collector-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         application: collector
     spec:
       containers:
-        - image: otel/opentelemetry-collector-contrib:0.67.0
+        - image: otel/opentelemetry-collector-contrib:0.68.0
           args: ["--config", "file:/etc/otel/config.yaml"]
           imagePullPolicy: IfNotPresent
           name: collector


### PR DESCRIPTION
Allow headers to be set on the gRPC requests. These headers can be used for authorization or any other purpose. The example shows how basic authentication can be used.