### PR TITLE
use same build targets as OpenTelemetry .NET SDK

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
-		<VersionPrefix>0.2.0</VersionPrefix>
+		<VersionPrefix>0.3.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
Expand the build targets to include all those also supported by the OpenTelemetry .NET SDK. 

Fix #23.