### PR TITLE
fix example program

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
-		<VersionPrefix>0.3.0</VersionPrefix>
+		<VersionPrefix>0.4.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Example/Program.cs
@@ -84,7 +84,6 @@ class Program
         return new LoggerConfiguration()
           .MinimumLevel.Information()
           .Enrich.WithTraceIdAndSpanId()
-          .Enrich.WithOpenTelemetryException()
           .WriteTo.OpenTelemetry(
               endpoint: endpoint,
               protocol: protocol,


### PR DESCRIPTION
The example program was referencing an old, deleted enricher. Fix the program by removing that reference.