### PR TITLE
Fix build/publishing

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -24,6 +24,7 @@ foreach ($src in Get-ChildItem src/*) {
 	Write-Output "build: Packaging project in $src"
 
     & dotnet build -c Release --version-suffix=$buildSuffix
+    if($LASTEXITCODE -ne 0) { exit 1 }
 
     if($suffix) {
         & dotnet pack -c Release --include-source --no-build -o ../../artifacts --version-suffix=$suffix

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -70,7 +70,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         this LoggerSinkConfiguration sinkConfiguration,
         string endpoint = "http://localhost:4317/v1/logs",
         OtlpProtocol protocol = OtlpProtocol.GrpcProtobuf,
-        IDictionary<string, Object>? resourceAttributes = null,
+        IDictionary<string, object>? resourceAttributes = null,
         IDictionary<string, string>? headers = null,
         IFormatProvider? formatProvider = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -3,7 +3,7 @@
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
 		<VersionPrefix>0.4.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+		<TargetFramework>net6.0</TargetFramework>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -18,6 +18,7 @@
 		<RootNamespace>Serilog</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="" />


### PR DESCRIPTION
`System.Diagnostics.ActivityTraceId` and `ActivitySpanId` are not supported in any .NET Standard or .NET Framework version, only Core 3.0+:

https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitytraceid

Unfortunately, because of a missing exit code check in Build.ps1, we missed this when the earlier .NET targets were added.

This PR fixes the build script and gets the project back to a publishable state. Some discussion of framework version targeting will be needed - I've dropped the target back to the earliest .NET version that's still in support and includes the referenced types (`net6.0`) to get the ball rolling again.

See also #25
