### PR TITLE
JSON format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ are:
 - `OtlpProtocol.HttpProtobuf`: Sends a protobuf representation of the
    OpenTelemetry Logs over an HTTP connection.
 
-Sending OpenTelemetry logs as a JSON payload is not supported. 
+### Message Format
+
+The default message format is plain text. You may also want to set the
+format explicitly. The supported values are:
+
+- `MessageFormat.PlainText`: Sends the message as plain text.
+- `MessageFormat.Json`     : Sends the message formatted as JSON.
 
 ### Resource Attributes
 

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -71,6 +71,9 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// <param name="disableBatching">
     /// The flag disabling batching in the sink.
     /// </param>
+    /// <param name="messageFormat">
+    /// The format in which log message is sent. Defaults to PlainText.
+    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration OpenTelemetry(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -84,7 +87,8 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         int batchSizeLimit = 100,
         int batchPeriod = 2,
         int batchQueueLimit = 10000,
-        bool disableBatching = false)
+        bool disableBatching = false,
+        MessageFormat messageFormat = MessageFormat.PlainText)
     {
         if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
 
@@ -93,7 +97,8 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             protocol: protocol,
             formatProvider: formatProvider,
             resourceAttributes: resourceAttributes,
-            headers: headers);
+            headers: headers,
+            messageFormat: messageFormat);
 
         ILogEventSink sink = openTelemetrySink;
         if (!disableBatching)


### PR DESCRIPTION
Added support to export the message as JSON.
Now, there is the option to export the messages as plain text (the current implementation), like this:
![image](https://user-images.githubusercontent.com/6213446/228523218-dd51503b-1154-4566-b646-96d9d9ff1816.png)

or newly in JSON that appears in Splunk in this way:
![image](https://user-images.githubusercontent.com/6213446/228523319-fabe310b-7d7e-40b5-9a46-ebb3bcd76734.png)