### PR TITLE
Allow custom TraceId and SpanId collection

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -38,8 +38,8 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         var options = new OpenTelemetrySinkOptions();
         configure(options);
 
-        var collector = new ActivityContextCollector();
-        
+        var collector = options.ActivityContextCollector ?? new ActivityContextCollector();
+
         var openTelemetrySink = new OpenTelemetrySink(
             endpoint: options.Endpoint,
             protocol: options.Protocol,
@@ -47,7 +47,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             resourceAttributes: options.ResourceAttributes,
             headers: options.Headers,
             includedData: options.IncludedData,
-            collector);
+            activityContextCollector: collector);
 
         ILogEventSink sink = openTelemetrySink;
         if (options.BatchingOptions != null)
@@ -55,9 +55,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             sink = new PeriodicBatchingSink(openTelemetrySink, options.BatchingOptions);
         }
 
-#if FEATURE_ACTIVITY
         sink = new ActivityContextCollectorSink(collector, sink);
-#endif
         
         return loggerSinkConfiguration.Sink(sink, options.RestrictedToMinimumLevel, options.LevelSwitch);
     }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ActivityContextCollectorSink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ActivityContextCollectorSink.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_ACTIVITY
-
 using Serilog.Core;
 using Serilog.Events;
 
@@ -26,10 +24,10 @@ namespace Serilog.Sinks.OpenTelemetry;
 /// <seealso cref="ActivityContextCollector"/>.
 sealed class ActivityContextCollectorSink : ILogEventSink, IDisposable
 {
-    readonly ActivityContextCollector _collector;
+    readonly IActivityContextCollector _collector;
     readonly ILogEventSink _inner;
     
-    public ActivityContextCollectorSink(ActivityContextCollector collector, ILogEventSink inner)
+    public ActivityContextCollectorSink(IActivityContextCollector collector, ILogEventSink inner)
     {
         _collector = collector;
         _inner = inner;
@@ -46,5 +44,3 @@ sealed class ActivityContextCollectorSink : ILogEventSink, IDisposable
         (_inner as IDisposable)?.Dispose();
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IActivityContextCollector.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IActivityContextCollector.cs
@@ -1,0 +1,23 @@
+using Serilog.Events;
+
+namespace Serilog.Sinks.OpenTelemetry;
+
+/// <summary>
+/// Collects and Provides TraceId and SpanId Information for a given <see cref="LogEvent">LogEvent</see>
+/// </summary>
+
+public interface IActivityContextCollector
+{
+    /// <summary>
+    /// Collects TraceId and SpanId information for the given <see cref="LogEvent">LogEvent</see>
+    /// </summary>
+    /// <param name="logEvent">The <see cref="LogEvent">LogEvent</see> to collect TraceId and SpanId for</param>
+    void CollectFor(LogEvent logEvent);
+
+    /// <summary>
+    /// Provides the previously collected TraceId and SpanId information for a given <see cref="LogEvent">LogEvent</see>
+    /// </summary>
+    /// <param name="logEvent">The <see cref="LogEvent">LogEvent</see> to provide TraceId and SpanId for</param>
+    /// <returns>The collected TraceId and SpanId</returns>
+    (string TraceId, string SpanId)? GetFor(LogEvent logEvent);
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordFactory.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordFactory.cs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if FEATURE_ACTIVITY
-using System.Diagnostics;
-#endif
-
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Trace;
@@ -39,7 +35,7 @@ static class LogRecordFactory
     /// <see cref="TraceSemanticConventions"/>.</remarks>
     public const string AttributeMessageTemplateMD5Hash = "message_template.md5_hash";
 
-    public static LogRecord ToLogRecord(LogEvent logEvent, IFormatProvider? formatProvider, IncludedData includedFields, ActivityContextCollector activityContextCollector)
+    public static LogRecord ToLogRecord(LogEvent logEvent, IFormatProvider? formatProvider, IncludedData includedFields, IActivityContextCollector activityContextCollector)
     {
         var logRecord = new LogRecord();
 
@@ -110,9 +106,8 @@ static class LogRecordFactory
         }
     }
 
-    static void ProcessIncludedFields(LogRecord logRecord, LogEvent logEvent, IncludedData includedFields, ActivityContextCollector activityContextCollector)
+    static void ProcessIncludedFields(LogRecord logRecord, LogEvent logEvent, IncludedData includedFields, IActivityContextCollector activityContextCollector)
     {
-#if FEATURE_ACTIVITY
         if ((includedFields & (IncludedData.TraceIdField | IncludedData.SpanIdField)) != IncludedData.None)
         {
             var activityContext = activityContextCollector.GetFor(logEvent);
@@ -121,16 +116,15 @@ static class LogRecordFactory
             {
                 if ((includedFields & IncludedData.TraceIdField) != IncludedData.None)
                 {
-                    logRecord.TraceId = ConvertUtils.ToOpenTelemetryTraceId(activityTraceId.ToHexString());
+                    logRecord.TraceId = ConvertUtils.ToOpenTelemetryTraceId(activityTraceId);
                 }
 
                 if ((includedFields & IncludedData.SpanIdField) != IncludedData.None)
                 {
-                    logRecord.SpanId = ConvertUtils.ToOpenTelemetrySpanId(activitySpanId.ToHexString());
+                    logRecord.SpanId = ConvertUtils.ToOpenTelemetrySpanId(activitySpanId);
                 }
             }
         }
-#endif
 
         if ((includedFields & IncludedData.MessageTemplateTextAttribute) != IncludedData.None)
         {

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -26,7 +26,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
     readonly ExportLogsServiceRequest _requestTemplate;
     readonly IExporter _exporter;
     readonly IncludedData _includedData;
-    readonly ActivityContextCollector _activityContextCollector;
+    readonly IActivityContextCollector _activityContextCollector;
 
     public OpenTelemetrySink(
        string endpoint,
@@ -35,7 +35,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
        IDictionary<string, object>? resourceAttributes,
        IDictionary<string, string>? headers,
        IncludedData includedData,
-       ActivityContextCollector activityContextCollector)
+       IActivityContextCollector activityContextCollector)
     {
         _exporter = protocol switch
         {

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -86,4 +86,10 @@ public class OpenTelemetrySinkOptions
         Period = TimeSpan.FromSeconds(DefaultPeriodSeconds),
         QueueLimit = DefaultQueueLimit
     };
+    
+    /// <summary>
+    /// The <see cref="IActivityContextCollector">IActivityContextCollector</see> to use for getting TraceId and SpanId information.
+    /// If no collector is provided, the default collector only collects TraceId and SpanId when targeting net6.0 or higher.
+    /// </summary>
+    public IActivityContextCollector? ActivityContextCollector { get; set; }
 }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordFactoryTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordFactoryTests.cs
@@ -119,7 +119,7 @@ public class LogRecordFactoryTests
     {
         var logEvent = TestUtils.CreateLogEvent(messageTemplate: TestUtils.TestMessageTemplate);
         
-        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.MessageTemplateMD5HashAttribute, new());
+        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.MessageTemplateMD5HashAttribute, new ActivityContextCollector());
         
         var expectedHash = ConvertUtils.Md5Hash(TestUtils.TestMessageTemplate);
         var expectedAttribute = new KeyValue { Key = LogRecordFactory.AttributeMessageTemplateMD5Hash, Value = new() { StringValue = expectedHash }};
@@ -131,7 +131,7 @@ public class LogRecordFactoryTests
     {
         var logEvent = TestUtils.CreateLogEvent(messageTemplate: TestUtils.TestMessageTemplate);
         
-        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.MessageTemplateTextAttribute, new());
+        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.MessageTemplateTextAttribute, new ActivityContextCollector());
 
         var expectedAttribute = new KeyValue { Key = LogRecordFactory.AttributeMessageTemplateText, Value = new() { StringValue = TestUtils.TestMessageTemplate }};
         Assert.Contains(expectedAttribute, logRecord.Attributes);

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetryUtilsTests.cs
@@ -24,7 +24,7 @@ public class OpenTelemetryUtilsTests
     public void TestNoDuplicateLogs()
     {
         var logEvent = TestUtils.CreateLogEvent();
-        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.None, new());
+        var logRecord = LogRecordFactory.ToLogRecord(logEvent, null, IncludedData.None, new ActivityContextCollector());
 
         var requestTemplate = OpenTelemetryUtils.CreateRequestTemplate(null);
 


### PR DESCRIPTION
Implements and uses the `IActivityContextCollector` interface, which is extracted from `ActivityContextCollector`.  
One necessary change was that the `GetFor` Method now returns two strings instead of `ActivityTraceId` and `ActivitySpanId`, so that a reference to `System.Diagnostics.`~~ActivitySource~~`DiagnosticsSource` is not required.

This allows consumers of the library to decide for themselves if they want to have TraceId and SpanId information for projects targeting runtimes < net6.0 by implementing their own IActivityContextCollector. 

usage:
```csharp
.WriteTo.OpenTelemetry(opt =>
{
    opt.ActivityContextCollector = new MyCustomActivityContextCollector()
});
```
The default behavior (`opt.ActivityContextCollector == null`) remains the same (TraceId and SpanId only for net6.0 or higher)


I am horrible at writing comments, so any corrections are welcome!