### PR TITLE
Handle more primitive type conversions and ensure null properties are still included in output `LogRecord`s

### DIFF
--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -66,7 +66,7 @@ static class Program
         logger
             .ForContext("Elapsed", elapsedMs)
             .ForContext("protocol", protocol)
-            .Information("{@Position}", position);
+            .Information("Position is {@Position}", position);
 
         try
         {
@@ -74,14 +74,14 @@ static class Program
         }
         catch (Exception ex)
         {
-            logger.ForContext("protocol", protocol).Error(ex, "{@Roll}", roll);
+            logger.ForContext("protocol", protocol).Error(ex, "Error on roll {Roll}", roll);
         }
     }
 
     static ILogger GetLogger(OtlpProtocol protocol)
     {
-        var port = protocol == OtlpProtocol.HttpProtobuf ? 4318 : 4317;
-        var endpoint = $"http://127.0.0.1:{port}/v1/logs";
+        var port = protocol == OtlpProtocol.HttpProtobuf ? 4318 : 45341;
+        var endpoint = $"https://localhost:{port}/v1/logs";
 
         return new LoggerConfiguration()
           .MinimumLevel.Information()

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY;FEATURE_HALF</DefineConstants>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY;FEATURE_HALF</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY</DefineConstants>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -96,8 +96,12 @@ static class PrimitiveConversions
             decimal d => new AnyValue { DoubleValue = (double)d },
             string s => new AnyValue { StringValue = s },
             bool b => new AnyValue { BoolValue = b },
-            DateTime dateTime => new AnyValue { StringValue = dateTime.ToString("o") },
-            DateTimeOffset dateTimeOffset => new AnyValue { StringValue = dateTimeOffset.ToString("o") },
+            DateTime dateTime => new AnyValue { StringValue = dateTime.ToString("O") },
+            DateTimeOffset dateTimeOffset => new AnyValue { StringValue = dateTimeOffset.ToString("O") },
+#if FEATURE_DATE_AND_TIME_ONLY
+            DateOnly dateOnly => new AnyValue { StringValue = dateOnly.ToString("yyyy-MM-dd") },
+            TimeOnly timeOnly => new AnyValue { StringValue = timeOnly.ToString("O") },
+#endif
             // We may want to thread through the format provider that's used for message rendering, but where the
             // results are consumed by a computer system rather than by an individual user InvariantCulture is often
             // more predictable.


### PR DESCRIPTION
No tests are broken, but some more test coverage would be good.

I think it's worth considering a merge ahead of those, since handling of `null` especially is something that would be great to tighten up.