### PR TITLE
Add approval tests, remove gRPC service stubs from public API surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.received.txt

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -65,8 +65,8 @@ static class Program
 
         logger
             .ForContext("Elapsed", elapsedMs)
-            .ForContext("protocol", protocol)
-            .Information("{@Position}", position);
+            .ForContext("Protocol", protocol)
+            .Information("The position is {@Position}", position);
 
         try
         {
@@ -74,7 +74,7 @@ static class Program
         }
         catch (Exception ex)
         {
-            logger.ForContext("protocol", protocol).Error(ex, "{@Roll}", roll);
+            logger.ForContext("Protocol", protocol).Error(ex, "Error in roll {Roll}", roll);
         }
     }
 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Common.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Common.cs
@@ -12,7 +12,7 @@ using scg = global::System.Collections.Generic;
 namespace OpenTelemetry.Proto.Common.V1 {
 
   /// <summary>Holder for reflection information generated from opentelemetry/proto/common/v1/common.proto</summary>
-  public static partial class CommonReflection {
+  static partial class CommonReflection {
 
     #region Descriptor
     /// <summary>File descriptor for opentelemetry/proto/common/v1/common.proto</summary>
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Proto.Common.V1 {
   /// primitive value such as a string or integer or it may contain an arbitrary nested
   /// object containing arrays, key-value lists and primitives.
   /// </summary>
-  public sealed partial class AnyValue : pb::IMessage<AnyValue>
+  sealed partial class AnyValue : pb::IMessage<AnyValue>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -551,7 +551,7 @@ namespace OpenTelemetry.Proto.Common.V1 {
   /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
   /// since oneof in AnyValue does not allow repeated fields.
   /// </summary>
-  public sealed partial class ArrayValue : pb::IMessage<ArrayValue>
+  sealed partial class ArrayValue : pb::IMessage<ArrayValue>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -739,7 +739,7 @@ namespace OpenTelemetry.Proto.Common.V1 {
   /// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
   /// are semantically equivalent.
   /// </summary>
-  public sealed partial class KeyValueList : pb::IMessage<KeyValueList>
+  sealed partial class KeyValueList : pb::IMessage<KeyValueList>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -927,7 +927,7 @@ namespace OpenTelemetry.Proto.Common.V1 {
   /// KeyValue is a key-value pair that is used to store Span attributes, Link
   /// attributes, etc.
   /// </summary>
-  public sealed partial class KeyValue : pb::IMessage<KeyValue>
+  sealed partial class KeyValue : pb::IMessage<KeyValue>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -1166,7 +1166,7 @@ namespace OpenTelemetry.Proto.Common.V1 {
   /// InstrumentationScope is a message representing the instrumentation scope information
   /// such as the fully qualified name and version. 
   /// </summary>
-  public sealed partial class InstrumentationScope : pb::IMessage<InstrumentationScope>
+  sealed partial class InstrumentationScope : pb::IMessage<InstrumentationScope>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Logs.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Logs.cs
@@ -12,7 +12,7 @@ using scg = global::System.Collections.Generic;
 namespace OpenTelemetry.Proto.Logs.V1 {
 
   /// <summary>Holder for reflection information generated from opentelemetry/proto/logs/v1/logs.proto</summary>
-  public static partial class LogsReflection {
+  static partial class LogsReflection {
 
     #region Descriptor
     /// <summary>File descriptor for opentelemetry/proto/logs/v1/logs.proto</summary>
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// <summary>
   /// Possible values for LogRecord.SeverityNumber.
   /// </summary>
-  public enum SeverityNumber {
+  enum SeverityNumber {
     /// <summary>
     /// UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
     /// </summary>
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// <summary>
   /// Masks for LogRecord.flags field.
   /// </summary>
-  public enum LogRecordFlags {
+  enum LogRecordFlags {
     [pbr::OriginalName("LOG_RECORD_FLAG_UNSPECIFIED")] LogRecordFlagUnspecified = 0,
     [pbr::OriginalName("LOG_RECORD_FLAG_TRACE_FLAGS_MASK")] LogRecordFlagTraceFlagsMask = 255,
   }
@@ -136,7 +136,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// When new fields are added into this message, the OTLP request MUST be updated
   /// as well.
   /// </summary>
-  public sealed partial class LogsData : pb::IMessage<LogsData>
+  sealed partial class LogsData : pb::IMessage<LogsData>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -324,7 +324,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// <summary>
   /// A collection of ScopeLogs from a Resource.
   /// </summary>
-  public sealed partial class ResourceLogs : pb::IMessage<ResourceLogs>
+  sealed partial class ResourceLogs : pb::IMessage<ResourceLogs>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -599,7 +599,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// <summary>
   /// A collection of Logs produced by a Scope.
   /// </summary>
-  public sealed partial class ScopeLogs : pb::IMessage<ScopeLogs>
+  sealed partial class ScopeLogs : pb::IMessage<ScopeLogs>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -875,7 +875,7 @@ namespace OpenTelemetry.Proto.Logs.V1 {
   /// A log record according to OpenTelemetry Log Data Model:
   /// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
   /// </summary>
-  public sealed partial class LogRecord : pb::IMessage<LogRecord>
+  sealed partial class LogRecord : pb::IMessage<LogRecord>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/LogsService.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/LogsService.cs
@@ -12,7 +12,7 @@ using scg = global::System.Collections.Generic;
 namespace OpenTelemetry.Proto.Collector.Logs.V1 {
 
   /// <summary>Holder for reflection information generated from opentelemetry/proto/collector/logs/v1/logs_service.proto</summary>
-  public static partial class LogsServiceReflection {
+  static partial class LogsServiceReflection {
 
     #region Descriptor
     /// <summary>File descriptor for opentelemetry/proto/collector/logs/v1/logs_service.proto</summary>
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Proto.Collector.Logs.V1 {
 
   }
   #region Messages
-  public sealed partial class ExportLogsServiceRequest : pb::IMessage<ExportLogsServiceRequest>
+  sealed partial class ExportLogsServiceRequest : pb::IMessage<ExportLogsServiceRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Proto.Collector.Logs.V1 {
 
   }
 
-  public sealed partial class ExportLogsServiceResponse : pb::IMessage<ExportLogsServiceResponse>
+  sealed partial class ExportLogsServiceResponse : pb::IMessage<ExportLogsServiceResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
@@ -453,7 +453,7 @@ namespace OpenTelemetry.Proto.Collector.Logs.V1 {
 
   }
 
-  public sealed partial class ExportLogsPartialSuccess : pb::IMessage<ExportLogsPartialSuccess>
+  sealed partial class ExportLogsPartialSuccess : pb::IMessage<ExportLogsPartialSuccess>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/LogsServiceGrpc.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/LogsServiceGrpc.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Proto.Collector.Logs.V1 {
   /// OpenTelemetry and an collector, or between an collector and a central collector (in this
   /// case logs are sent/received to/from multiple Applications).
   /// </summary>
-  public static partial class LogsService
+  static partial class LogsService
   {
     static readonly string __ServiceName = "opentelemetry.proto.collector.logs.v1.LogsService";
 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Resource.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Proto/Resource.cs
@@ -12,7 +12,7 @@ using scg = global::System.Collections.Generic;
 namespace OpenTelemetry.Proto.Resource.V1 {
 
   /// <summary>Holder for reflection information generated from opentelemetry/proto/resource/v1/resource.proto</summary>
-  public static partial class ResourceReflection {
+  static partial class ResourceReflection {
 
     #region Descriptor
     /// <summary>File descriptor for opentelemetry/proto/resource/v1/resource.proto</summary>
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Proto.Resource.V1 {
   /// <summary>
   /// Resource information.
   /// </summary>
-  public sealed partial class Resource : pb::IMessage<Resource>
+  sealed partial class Resource : pb::IMessage<Resource>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -1,0 +1,39 @@
+﻿namespace Serilog
+{
+    public static class OpenTelemetryLoggerConfigurationExtensions
+    {
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions> configure) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, string endpoint = "http://localhost:4317/v1/logs", System.Net.Http.HttpMessageHandler? httpMessageHandler = null, Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0, System.Collections.Generic.IDictionary<string, object>? resourceAttributes = null, System.Collections.Generic.IDictionary<string, string>? headers = null, System.IFormatProvider? formatProvider = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null, int batchSizeLimit = 1000, System.TimeSpan? period = default, int queueLimit = 100000, bool disableBatching = false, Serilog.Sinks.OpenTelemetry.IncludedData includedData = 13) { }
+    }
+}
+namespace Serilog.Sinks.OpenTelemetry
+{
+    [System.Flags]
+    public enum IncludedData
+    {
+        None = 0,
+        MessageTemplateTextAttribute = 1,
+        MessageTemplateMD5HashAttribute = 2,
+        TraceIdField = 4,
+        SpanIdField = 8,
+    }
+    public class OpenTelemetrySinkOptions
+    {
+        public OpenTelemetrySinkOptions() { }
+        public Serilog.Sinks.PeriodicBatching.PeriodicBatchingSinkOptions? BatchingOptions { get; set; }
+        public string Endpoint { get; set; }
+        public System.IFormatProvider? FormatProvider { get; set; }
+        public System.Collections.Generic.IDictionary<string, string> Headers { get; set; }
+        public System.Net.Http.HttpMessageHandler? HttpMessageHandler { get; set; }
+        public Serilog.Sinks.OpenTelemetry.IncludedData IncludedData { get; set; }
+        public Serilog.Core.LoggingLevelSwitch? LevelSwitch { get; set; }
+        public Serilog.Sinks.OpenTelemetry.OtlpProtocol Protocol { get; set; }
+        public System.Collections.Generic.IDictionary<string, object> ResourceAttributes { get; set; }
+        public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
+    }
+    public enum OtlpProtocol
+    {
+        GrpcProtobuf = 0,
+        HttpProtobuf = 1,
+    }
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.cs
@@ -1,0 +1,25 @@
+﻿using PublicApiGenerator;
+using Shouldly;
+using Xunit;
+
+namespace Serilog.Sinks.OpenTelemetry.Tests;
+
+public class PublicApiVisibilityTests
+{
+    [Fact]
+    public void PublicApiShouldNotChangeUnintentionally()
+    {
+        var assembly = typeof(OpenTelemetryLoggerConfigurationExtensions).Assembly;
+        var publicApi = assembly.GeneratePublicApi(
+            new()
+            {
+                IncludeAssemblyAttributes = false,
+                ExcludeAttributes = new[] { "System.Diagnostics.DebuggerDisplayAttribute" },
+            });
+
+        publicApi.ShouldMatchApproved(options =>
+        {
+            options.WithFilenameGenerator((_, _, fileType, fileExtension) => $"{nameof(PublicApiVisibilityTests)}.{fileType}.{fileExtension}");
+        });
+    }    
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
@@ -11,11 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Checks that the exposed public API surface matches the expectations in the approved list. Caught the fact that the protocol types and service stubs were using the `public` modifier 😅 

Based on @SimonCropp's implementation for Serilog 🙇 