### PR TITLE
update message hash attribute to follow elastic common schema (fix #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Serilog `LogEvent`               | OpenTelemetry `LogRecord`                 | C
 `Level.ToString()`               | `SeverityText`                            |                                                                                               |
 `Message`                        | `Body`                                    | Culture-specific formatting can be provided via sink configuration                            |
 `MessageTemplate`                | `Attributes["message_template.text"]`     | Requires `IncludedData.MessageTemplateText` (enabled by default)                              |
-`MessageTemplate` (MD5)          | `Attributes["message_template.md5_hash"]` | Requires `IncludedData.MessageTemplateText`                                                   |
+`MessageTemplate` (MD5)          | `Attributes["message_template.hash.md5"]` | Requires `IncludedData.MessageTemplateMD5HashAttribute`                                                   |
 `Properties`                     | `Attributes`                              | Each property is mapped to an attribute keeping the name; the value's structure is maintained |
 `SpanId` (`Activity.Current`)    | `SpanId`                                  | Requires `IncludedData.SpanId` (enabled by default)                                           |
 `Timestamp`                      | `TimeUnixNano`                            | .NET provides 100-nanosecond precision                                                        |

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
@@ -34,7 +34,7 @@ public enum IncludedData
     MessageTemplateTextAttribute = 1,
     
     /// <summary>
-    /// Include an MD5 hash of the log event's message template as a hex-encoded string in <c>message_template.md5_hash</c>.
+    /// Include an MD5 hash of the log event's message template as a hex-encoded string in <c>message_template.hash.md5</c>.
     /// </summary>
     /// <remarks>See also https://messagetemplates.org.</remarks>
     MessageTemplateMD5HashAttribute = 2,

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
@@ -36,7 +36,7 @@ static class LogRecordBuilder
     /// </summary>
     /// <remarks>See also https://opentelemetry.io/docs/reference/specification/logs/semantic_conventions/ and
     /// <see cref="TraceSemanticConventions"/>.</remarks>
-    public const string AttributeMessageTemplateMD5Hash = "message_template.md5_hash";
+    public const string AttributeMessageTemplateMD5Hash = "message_template.hash.md5";
 
     public static LogRecord ToLogRecord(LogEvent logEvent, IFormatProvider? formatProvider, IncludedData includedFields, ActivityContextCollector activityContextCollector)
     {


### PR DESCRIPTION
Rename the `message_template.md5_hash` attribute to `message_template.hash.md5` to follow the [ECS hash conventions](https://www.elastic.co/guide/en/ecs/current/ecs-hash.html). Update associated documentation.