### PR TITLE
Remove `headers` argument, update README to show options overload in configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Log.Logger = new LoggerConfiguration()
 Then use the `Log.Information(...)` and similar methods to send 
 transformed logs to a local OpenTelemetry (OTLP/gRPC) endpoint.
 
-A more complete configuration would specify the `endpoint` and
-`resourceAttributes`. 
+A more complete configuration would specify `Endpoint` and
+`ResourceAttributes` as shown in the examples below.~~~~
 
 ### Endpoint and protocol
 
@@ -76,15 +76,17 @@ the logger is configured.
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.OpenTelemetry(
-        endpoint: "http://127.0.0.1:4317/v1/logs",
-        resourceAttributes: new Dictionary<string, object>
+    .WriteTo.OpenTelemetry(options =>
+    {
+        options.Endpoint = "http://127.0.0.1:4317/v1/logs";
+        options.ResourceAttributes = new Dictionary<string, object>
         {
             ["service.name"] = "test-logging-service",
             ["index"] = 10,
             ["flag"] = true,
             ["value"] = 3.14
-        })
+        };
+    })
     .CreateLogger();
 ```
 
@@ -115,9 +117,11 @@ the Serilog `LogEvent` and .NET `Activity` context via the `IncludedData` flags 
 
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .WriteTo.OpenTelemetry(
-        endpoint: "http://127.0.0.1:4317/v1/logs",
-        includedData: IncludedData.MessageTemplate | IncludedData.TraceId | IncludedData.SpanId)
+    .WriteTo.OpenTelemetry(options =>
+    {
+        options.Endpoint = "http://127.0.0.1:4317/v1/logs";
+        options.IncludedData: IncludedData.MessageTemplate | IncludedData.TraceId | IncludedData.SpanId;
+    })
     .CreateLogger();
 ```
 

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -71,15 +71,11 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// <param name="protocol">
     /// The OTLP protocol to use.
     /// </param>
-    /// <param name="headers">
-    /// Headers to send with network requests.
-    /// </param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     public static LoggerConfiguration OpenTelemetry(
         this LoggerSinkConfiguration loggerSinkConfiguration,
         string endpoint = OpenTelemetrySinkOptions.DefaultEndpoint,
-        OtlpProtocol protocol = OpenTelemetrySinkOptions.DefaultProtocol,
-        IDictionary<string, string>? headers = null)
+        OtlpProtocol protocol = OpenTelemetrySinkOptions.DefaultProtocol)
     {
         if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
 
@@ -87,7 +83,6 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         {
             options.Endpoint = endpoint;
             options.Protocol = protocol;
-            options.Headers = headers ?? new Dictionary<string, string>();
         });
     }
 }


### PR DESCRIPTION
Fixes #70 
See also https://github.com/serilog/serilog-sinks-opentelemetry/issues/59#issuecomment-1532288456