### PR TITLE
Implement `AuditTo` support

### DIFF
--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -19,7 +19,6 @@
 using Serilog;
 using System.Diagnostics;
 using Serilog.Sinks.OpenTelemetry;
-using Serilog.Sinks.PeriodicBatching;
 
 namespace Example;
 
@@ -82,7 +81,7 @@ static class Program
     static ILogger GetLogger(OtlpProtocol protocol)
     {
         var port = protocol == OtlpProtocol.HttpProtobuf ? 4318 : 4317;
-        var endpoint = $"https://localhost:{port}/v1/logs";
+        var endpoint = $"http://localhost:{port}/v1/logs";
 
         return new LoggerConfiguration()
             .MinimumLevel.Information()
@@ -105,12 +104,9 @@ static class Program
                 {
                     ["Authorization"] = "Basic dXNlcjphYmMxMjM=", // user:abc123
                 };
-                options.BatchingOptions = new PeriodicBatchingSinkOptions()
-                {
-                    BatchSizeLimit = 2,
-                    Period = TimeSpan.FromSeconds(2),
-                    QueueLimit = 10
-                };
+                options.BatchingOptions.BatchSizeLimit = 2;
+                options.BatchingOptions.Period = TimeSpan.FromSeconds(2);
+                options.BatchingOptions.QueueLimit = 10;
             })
             .CreateLogger();
     }

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -27,13 +27,17 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// <summary>
     /// Send log events to an OTLP exporter.
     /// </summary>
+    /// <param name="loggerSinkConfiguration">
+    /// The `WriteTo` configuration object.
+    /// </param>
+    /// <param name="configure">The configuration callback.</param>
     public static LoggerConfiguration OpenTelemetry(
         this LoggerSinkConfiguration loggerSinkConfiguration,
-        Action<OpenTelemetrySinkOptions> configure)
+        Action<BatchedOpenTelemetrySinkOptions> configure)
     {
         if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-        var options = new OpenTelemetrySinkOptions();
+        var options = new BatchedOpenTelemetrySinkOptions();
         configure(options);
 
         var collector = new ActivityContextCollector();
@@ -48,11 +52,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             httpMessageHandler: options.HttpMessageHandler,
             activityContextCollector: collector);
 
-        ILogEventSink sink = openTelemetrySink;
-        if (options.BatchingOptions != null)
-        {
-            sink = new PeriodicBatchingSink(openTelemetrySink, options.BatchingOptions);
-        }
+        ILogEventSink sink = new PeriodicBatchingSink(openTelemetrySink, options.BatchingOptions);
 
         sink = new ActivityContextCollectorSink(collector, sink);
         
@@ -63,7 +63,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// Send log events to an OTLP exporter.
     /// </summary>
     /// <param name="loggerSinkConfiguration">
-    /// The logger configuration.
+    /// The `WriteTo` configuration object.
     /// </param>
     /// <param name="endpoint">
     /// The full URL of the OTLP exporter endpoint.
@@ -80,6 +80,67 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
 
         return loggerSinkConfiguration.OpenTelemetry(options =>
+        {
+            options.Endpoint = endpoint;
+            options.Protocol = protocol;
+        });
+    }
+    
+    /// <summary>
+    /// Audit to an OTLP exporter, waiting for each event to be acknowledged, and propagating errors to the caller.
+    /// </summary>
+    /// <param name="loggerAuditSinkConfiguration">
+    /// The `AuditTo` configuration object.
+    /// </param>
+    /// <param name="configure">The configuration callback. Note that </param>
+    public static LoggerConfiguration OpenTelemetry(
+        this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
+        Action<OpenTelemetrySinkOptions> configure)
+    {
+        if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+        var options = new OpenTelemetrySinkOptions();
+        
+        configure(options);
+
+        var collector = new ActivityContextCollector();
+        
+        var openTelemetrySink = new OpenTelemetrySink(
+            endpoint: options.Endpoint,
+            protocol: options.Protocol,
+            formatProvider: options.FormatProvider,
+            resourceAttributes: options.ResourceAttributes,
+            headers: options.Headers,
+            includedData: options.IncludedData,
+            httpMessageHandler: options.HttpMessageHandler,
+            activityContextCollector: collector);
+
+        var sink = new ActivityContextCollectorSink(collector, openTelemetrySink);
+        
+        return loggerAuditSinkConfiguration.Sink(sink, options.RestrictedToMinimumLevel, options.LevelSwitch);
+    }
+    
+    /// <summary>
+    /// Audit to an OTLP exporter, waiting for each event to be acknowledged, and propagating errors to the caller.
+    /// </summary>
+    /// <param name="loggerAuditSinkConfiguration">
+    /// The `AuditTo` configuration object.
+    /// </param>
+    /// <param name="endpoint">
+    /// The full URL of the OTLP exporter endpoint.
+    /// </param>
+    /// <param name="protocol">
+    /// The OTLP protocol to use.
+    /// </param>
+    /// <returns>Logger configuration, allowing configuration to continue.</returns>
+    public static LoggerConfiguration OpenTelemetry(
+        this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
+        string endpoint = OpenTelemetrySinkOptions.DefaultEndpoint,
+        OtlpProtocol protocol = OpenTelemetrySinkOptions.DefaultProtocol)
+    {
+        if (loggerAuditSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
+
+        return loggerAuditSinkConfiguration.OpenTelemetry(options =>
         {
             options.Endpoint = endpoint;
             options.Protocol = protocol;

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -92,7 +92,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// <param name="loggerAuditSinkConfiguration">
     /// The `AuditTo` configuration object.
     /// </param>
-    /// <param name="configure">The configuration callback. Note that </param>
+    /// <param name="configure">The configuration callback.</param>
     public static LoggerConfiguration OpenTelemetry(
         this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
         Action<OpenTelemetrySinkOptions> configure)

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -18,6 +18,10 @@
 		<DefineConstants>$(DefineConstants);FEATURE_CWT_ADDORUPDATE;FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY</DefineConstants>
 	</PropertyGroup>
 	
+	<PropertyGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+		<DefineConstants>$(DefineConstants);NO_SYNC_HTTP_SEND</DefineConstants>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="" />
 		<PackageReference Include="Google.Protobuf" Version="3.21.11" />

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/GrpcExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/GrpcExporter.cs
@@ -66,19 +66,17 @@ sealed class GrpcExporter : IExporter, IDisposable
         }
     }
 
-    /// <summary>
-    /// Frees the gRPC channel used to send logs to the OTLP endpoint.
-    /// </summary>
     public void Dispose()
     {
         _channel.Dispose();
     }
 
-    /// <summary>
-    /// Sends the given protobuf request containing OpenTelemetry logs
-    /// to an gRPC/HTTP endpoint.
-    /// </summary>
-    Task IExporter.Export(ExportLogsServiceRequest request)
+    public void Export(ExportLogsServiceRequest request)
+    {
+        _client.Export(request, _headers);
+    }
+
+    public Task ExportAsync(ExportLogsServiceRequest request)
     {
         return _client.ExportAsync(request, _headers).ResponseAsync;
     }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IExporter.cs
@@ -14,7 +14,10 @@
 
 using OpenTelemetry.Proto.Collector.Logs.V1;
 
+namespace Serilog.Sinks.OpenTelemetry;
+
 interface IExporter
 {
-    Task Export(ExportLogsServiceRequest request);
+    void Export(ExportLogsServiceRequest request);
+    Task ExportAsync(ExportLogsServiceRequest request);
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -25,10 +25,10 @@ namespace Serilog.Sinks.OpenTelemetry;
 public class OpenTelemetrySinkOptions
 {
     internal const string DefaultEndpoint = "http://localhost:4317/v1/logs";
-    internal const int DefaultBatchSizeLimit = 1000, DefaultPeriodSeconds = 2, DefaultQueueLimit = 100000;
     internal const OtlpProtocol DefaultProtocol = OtlpProtocol.GrpcProtobuf;
-    internal const IncludedData DefaultIncludedData = IncludedData.MessageTemplateTextAttribute |
-                                                         IncludedData.TraceIdField | IncludedData.SpanIdField;
+
+    const IncludedData DefaultIncludedData = IncludedData.MessageTemplateTextAttribute |
+                                             IncludedData.TraceIdField | IncludedData.SpanIdField;
 
     /// <summary>
     /// The full URL of the OTLP exporter endpoint.
@@ -39,7 +39,7 @@ public class OpenTelemetrySinkOptions
     /// Custom HTTP message handler.
     /// </summary>
     public HttpMessageHandler? HttpMessageHandler { get; set; }
-    
+
     /// <summary>
     /// The OTLP protocol to use.
     /// </summary>
@@ -78,12 +78,19 @@ public class OpenTelemetrySinkOptions
     /// to be changed at runtime.
     /// </summary>
     public LoggingLevelSwitch? LevelSwitch { get; set; }
+}
+
+/// <summary>
+/// Options type for 
+/// </summary>
+public class BatchedOpenTelemetrySinkOptions : OpenTelemetrySinkOptions
+{
+    const int DefaultBatchSizeLimit = 1000, DefaultPeriodSeconds = 2, DefaultQueueLimit = 100000;
 
     /// <summary>
-    /// Options that control the sending of asynchronous log batches. Set to <c>null</c> to disable
-    /// batching.
+    /// Options that control the sending of asynchronous log batches. When <c>null</c> a batch size of 1 is used.
     /// </summary>
-    public PeriodicBatchingSinkOptions? BatchingOptions { get; set; } = new()
+    public PeriodicBatchingSinkOptions BatchingOptions { get; } = new()
     {
         EagerlyEmitFirstEvent = true,
         BatchSizeLimit = DefaultBatchSizeLimit,

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -2,12 +2,19 @@
 {
     public static class OpenTelemetryLoggerConfigurationExtensions
     {
-        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions> configure) { }
-        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, string endpoint = "http://localhost:4317/v1/logs", System.Net.Http.HttpMessageHandler? httpMessageHandler = null, Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0, System.Collections.Generic.IDictionary<string, object>? resourceAttributes = null, System.Collections.Generic.IDictionary<string, string>? headers = null, System.IFormatProvider? formatProvider = null, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null, int batchSizeLimit = 1000, System.TimeSpan? period = default, int queueLimit = 100000, bool disableBatching = false, Serilog.Sinks.OpenTelemetry.IncludedData includedData = 13) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerAuditSinkConfiguration loggerAuditSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions> configure) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.BatchedOpenTelemetrySinkOptions> configure) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerAuditSinkConfiguration loggerAuditSinkConfiguration, string endpoint = "http://localhost:4317/v1/logs", Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, string endpoint = "http://localhost:4317/v1/logs", Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0) { }
     }
 }
 namespace Serilog.Sinks.OpenTelemetry
 {
+    public class BatchedOpenTelemetrySinkOptions : Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions
+    {
+        public BatchedOpenTelemetrySinkOptions() { }
+        public Serilog.Sinks.PeriodicBatching.PeriodicBatchingSinkOptions BatchingOptions { get; }
+    }
     [System.Flags]
     public enum IncludedData
     {
@@ -20,7 +27,6 @@ namespace Serilog.Sinks.OpenTelemetry
     public class OpenTelemetrySinkOptions
     {
         public OpenTelemetrySinkOptions() { }
-        public Serilog.Sinks.PeriodicBatching.PeriodicBatchingSinkOptions? BatchingOptions { get; set; }
         public string Endpoint { get; set; }
         public System.IFormatProvider? FormatProvider { get; set; }
         public System.Collections.Generic.IDictionary<string, string> Headers { get; set; }


### PR DESCRIPTION
I realised when reviewing #59 that we haven't implemented `AuditTo`, which Serilog provides to support guaranteed-delivered, single-event transport:

```csharp
Log.Logger = new LoggerConfiguration()
    .AuditTo.OpenTelemetry(opts => ...)
    .CreateLogger();

// Throws if logging fails
Log.Information("Starting up");
```

In doing this I realised that the single-event mode previously implemented in the sink has some issues, namely, the channel may be disposed while the event is in flight.

Other Serilog sinks rely on a combination of `AuditTo` and `WriteTo.Async` to cover similar scenarios - I think we should avoid blazing a new trail here with the 1.0, and try to close any remaining gaps further down the line.

The PR splits the options type into `OpenTelemetrySinkOptions` and `BatchedOpenTelemetrySinkOptions`; I'm not thrilled with the naming, but these are largely hidden from users of the API so may not warrant tooooo much concern.

Also reverts the scheme part of the sample program's default endpoint URL to HTTP :-) (hopefully fixes #69).