### PR TITLE
Break long lines in `README` table/code sample to avoid scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,20 +95,20 @@ Log.Logger = new LoggerConfiguration()
 The following table provides the mapping between the Serilog log 
 events and the OpenTelemetry log records. 
 
-Serilog `LogEvent`               | OpenTelemetry `LogRecord`                 | Comments                                                                                      |
----------------------------------|-------------------------------------------|-----------------------------------------------------------------------------------------------| 
-`Exception.GetType().ToString()` | `Attributes["exception.type"]`            |                                                                                               |
-`Exception.Message`              | `Attributes["exception.message"]`         | Ignored if empty                                                                              |
-`Exception.StackTrace`           | `Attributes["exception.stacktrace"]`      | Value of `ex.ToString()`                                                                      |
-`Level`                          | `SeverityNumber`                          | Serilog levels are mapped to corresponding OpenTelemetry severities                           | 
-`Level.ToString()`               | `SeverityText`                            |                                                                                               |
-`Message`                        | `Body`                                    | Culture-specific formatting can be provided via sink configuration                            |
-`MessageTemplate`                | `Attributes["message_template.text"]`     | Requires `IncludedData.MessageTemplateText` (enabled by default)                              |
-`MessageTemplate` (MD5)          | `Attributes["message_template.hash.md5"]` | Requires `IncludedData.MessageTemplateMD5HashAttribute`                                                   |
-`Properties`                     | `Attributes`                              | Each property is mapped to an attribute keeping the name; the value's structure is maintained |
-`SpanId` (`Activity.Current`)    | `SpanId`                                  | Requires `IncludedData.SpanId` (enabled by default)                                           |
-`Timestamp`                      | `TimeUnixNano`                            | .NET provides 100-nanosecond precision                                                        |
-`TraceId` (`Activity.Current`)   | `TraceId`                                 | Requires `IncludedData.TraceId` (enabled by default)                                          |
+Serilog `LogEvent`               | OpenTelemetry `LogRecord`                  | Comments                                                                                      |
+---------------------------------|--------------------------------------------|-----------------------------------------------------------------------------------------------| 
+`Exception.GetType().ToString()` | `Attributes["exception.type"]`             |                                                                                               |
+`Exception.Message`              | `Attributes["exception.message"]`          | Ignored if empty                                                                              |
+`Exception.StackTrace`           | `Attributes[ "exception.stacktrace"]`      | Value of `ex.ToString()`                                                                      |
+`Level`                          | `SeverityNumber`                           | Serilog levels are mapped to corresponding OpenTelemetry severities                           | 
+`Level.ToString()`               | `SeverityText`                             |                                                                                               |
+`Message`                        | `Body`                                     | Culture-specific formatting can be provided via sink configuration                            |
+`MessageTemplate`                | `Attributes[ "message_template.text"]`     | Requires `IncludedData. MessageTemplateText` (enabled by default)                             |
+`MessageTemplate` (MD5)          | `Attributes[ "message_template.hash.md5"]` | Requires `IncludedData. MessageTemplateMD5 HashAttribute`                                     |
+`Properties`                     | `Attributes`                               | Each property is mapped to an attribute keeping the name; the value's structure is maintained |
+`SpanId` (`Activity.Current`)    | `SpanId`                                   | Requires `IncludedData.SpanId` (enabled by default)                                           |
+`Timestamp`                      | `TimeUnixNano`                             | .NET provides 100-nanosecond precision                                                        |
+`TraceId` (`Activity.Current`)   | `TraceId`                                  | Requires `IncludedData.TraceId` (enabled by default)                                          |
 
 ### Configuring included data
 
@@ -120,7 +120,8 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(options =>
     {
         options.Endpoint = "http://127.0.0.1:4317/v1/logs";
-        options.IncludedData: IncludedData.MessageTemplate | IncludedData.TraceId | IncludedData.SpanId;
+        options.IncludedData: IncludedData.MessageTemplate |
+                              IncludedData.TraceId | IncludedData.SpanId;
     })
     .CreateLogger();
 ```


### PR DESCRIPTION
The current README ends up with horizontal scroll bars in a few places. The added breaks result in a more polished reading experience:

![image](https://user-images.githubusercontent.com/342712/236350315-8cfefe03-e1bb-4733-8678-c600c7ab8258.png)
