### PR TITLE
Break dependency on `OpenTelemetry.SemanticConventions`

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -27,7 +27,6 @@
 		<PackageReference Include="Google.Protobuf" Version="3.21.11" />
 		<PackageReference Include="Grpc" Version="2.46.5" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
-		<PackageReference Include="OpenTelemetry.SemanticConventions" Version="1.0.0-rc9.9" />
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
 	</ItemGroup>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
@@ -14,7 +14,6 @@
 
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
-using OpenTelemetry.Trace;
 using Serilog.Events;
 using Serilog.Sinks.OpenTelemetry.Formatting;
 using Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
@@ -23,20 +22,6 @@ namespace Serilog.Sinks.OpenTelemetry;
 
 static class LogRecordBuilder
 {
-    /// <summary>
-    /// A https://messagetemplates.org template, as text. For example, the string <c>Hello {Name}!</c>.
-    /// </summary>
-    /// <remarks>See also https://opentelemetry.io/docs/reference/specification/logs/semantic_conventions/ and
-    /// <see cref="TraceSemanticConventions"/>.</remarks>
-    public  const string AttributeMessageTemplateText = "message_template.text";
-
-    /// <summary>
-    /// A https://messagetemplates.org template, hashed using MD5 and encoded as a 128-bit hexadecimal value.
-    /// </summary>
-    /// <remarks>See also https://opentelemetry.io/docs/reference/specification/logs/semantic_conventions/ and
-    /// <see cref="TraceSemanticConventions"/>.</remarks>
-    public const string AttributeMessageTemplateMD5Hash = "message_template.hash.md5";
-
     public static LogRecord ToLogRecord(LogEvent logEvent, IFormatProvider? formatProvider, IncludedData includedFields, ActivityContextCollector activityContextCollector)
     {
         var logRecord = new LogRecord();
@@ -75,10 +60,7 @@ static class LogRecordBuilder
         foreach (var property in logEvent.Properties)
         {
             var v = PrimitiveConversions.ToOpenTelemetryAnyValue(property.Value);
-            if (v != null)
-            {
-                logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(property.Key, v));
-            }
+            logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(property.Key, v));
         }
     }
 
@@ -94,16 +76,16 @@ static class LogRecordBuilder
         {
             var attrs = logRecord.Attributes;
 
-            attrs.Add(PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionType, ex.GetType().ToString()));
+            attrs.Add(PrimitiveConversions.NewStringAttribute(SemanticConventions.AttributeExceptionType, ex.GetType().ToString()));
 
             if (ex.Message != "")
             {
-                attrs.Add(PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionMessage, ex.Message));
+                attrs.Add(PrimitiveConversions.NewStringAttribute(SemanticConventions.AttributeExceptionMessage, ex.Message));
             }
 
             if (ex.ToString() != "")
             {
-                attrs.Add(PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionStacktrace, ex.ToString()));
+                attrs.Add(PrimitiveConversions.NewStringAttribute(SemanticConventions.AttributeExceptionStacktrace, ex.ToString()));
             }
         }
     }
@@ -130,7 +112,7 @@ static class LogRecordBuilder
 
         if ((includedFields & IncludedData.MessageTemplateTextAttribute) != IncludedData.None)
         {
-            logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(AttributeMessageTemplateText, new()
+            logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(SemanticConventions.AttributeMessageTemplateText, new()
             {
                 StringValue = logEvent.MessageTemplate.Text
             }));
@@ -138,7 +120,7 @@ static class LogRecordBuilder
 
         if ((includedFields & IncludedData.MessageTemplateMD5HashAttribute) != IncludedData.None)
         {
-            logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(AttributeMessageTemplateMD5Hash, new()
+            logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(SemanticConventions.AttributeMessageTemplateMD5Hash, new()
             {
                 StringValue = PrimitiveConversions.Md5Hash(logEvent.MessageTemplate.Text)
             }));

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/SemanticConventions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/SemanticConventions.cs
@@ -1,0 +1,33 @@
+﻿namespace Serilog.Sinks.OpenTelemetry;
+
+/// <summary>
+/// Well-known attribute names.
+/// </summary>
+/// <remarks>See also https://opentelemetry.io/docs/reference/specification/logs/semantic_conventions/.</remarks>
+static class SemanticConventions
+{
+    /// <summary>
+    /// OpenTelemetry standard exception type attribute.
+    /// </summary>
+    public const string AttributeExceptionType = "exception.type";
+
+    /// <summary>
+    /// OpenTelemetry standard exception type attribute.
+    /// </summary>
+    public const string AttributeExceptionMessage = "exception.message";
+    
+    /// <summary>
+    /// OpenTelemetry standard exception type attribute.
+    /// </summary>
+    public const string AttributeExceptionStacktrace = "exception.stacktrace";
+
+    /// <summary>
+    /// A https://messagetemplates.org template, as text. For example, the string <c>Hello {Name}!</c>.
+    /// </summary>
+    public  const string AttributeMessageTemplateText = "message_template.text";
+
+    /// <summary>
+    /// A https://messagetemplates.org template, hashed using MD5 and encoded as a 128-bit hexadecimal value.
+    /// </summary>
+    public const string AttributeMessageTemplateMD5Hash = "message_template.hash.md5";
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
@@ -123,7 +123,7 @@ public class LogRecordBuilderTests
         var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateMD5HashAttribute, new());
         
         var expectedHash = PrimitiveConversions.Md5Hash(Some.TestMessageTemplate);
-        var expectedAttribute = new KeyValue { Key = LogRecordBuilder.AttributeMessageTemplateMD5Hash, Value = new() { StringValue = expectedHash }};
+        var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateMD5Hash, Value = new() { StringValue = expectedHash }};
         Assert.Contains(expectedAttribute, logRecord.Attributes);
     }
     
@@ -134,7 +134,7 @@ public class LogRecordBuilderTests
         
         var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateTextAttribute, new());
 
-        var expectedAttribute = new KeyValue { Key = LogRecordBuilder.AttributeMessageTemplateText, Value = new() { StringValue = Some.TestMessageTemplate }};
+        var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateText, Value = new() { StringValue = Some.TestMessageTemplate }};
         Assert.Contains(expectedAttribute, logRecord.Attributes);
     }
     

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <IsPackable>False</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="OpenTelemetry.SemanticConventions" Version="1.0.0-rc9.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #78

(Also saves quite a bit of unnecessary dependency footprint 😎 )