### PR TITLE
Rename `OtlpProtocol.GrpcProtobuf` to `OtlpProtocol.Grpc`, fix documentation for gRPC endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
-The example shows the default value; `IncludedData.MessageTemplateMD5HashAttribute`~~~~ can
+The example shows the default value; `IncludedData.MessageTemplateMD5HashAttribute` can
 also be used to add the MD5 hash of the message template.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ inline configuration looks like:
 ```csharp
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(
-        endpoint: "http://127.0.0.1:4317/v1/logs",
-        protocol: OtlpProtocol.Grpc)
+        endpoint: "http://127.0.0.1:4318/v1/logs",
+        protocol: OtlpProtocol.HttpProtobuf)
     .CreateLogger();
 ```
 
@@ -60,8 +60,8 @@ configuration, which looks like:
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(options =>
     {
-        options.Endpoint = endpoint;
-        options.Protocol = protocol;
+        options.Endpoint = "http://127.0.0.1:4318/v1/logs";
+        options.Protocol = OtlpProtocol.HttpProtobuf;
     })
     .CreateLogger();
 
@@ -74,25 +74,24 @@ sections.
 
 ### Endpoint and protocol
 
-The default endpoint is `http://localhost:4317/v1/logs`, which will send
-logs formatted as a protobuf payload to an OpenTelemetry collector
-running on the same machine over the gRPC protocol. This is appropriate
-for testing or for using a local OpenTelemetry collector as a proxy for
-a downstream logging service.
+The default endpoint is `http://localhost:4317`, which will send
+logs to an OpenTelemetry collector running on the same machine over
+the gRPC protocol. This is appropriate for testing or for using a 
+local OpenTelemetry collector as a proxy for a downstream logging service.
 
 In most production scenarios, you will want to set an endpoint. To do so,
-add the `endpoint` argument to the `WriteTo.OpenTelemetry()` call. This
-must be the **full** URL to an OTLP/gRPC endpoint.
+add the `endpoint` argument to the `WriteTo.OpenTelemetry()` call.
 
 You may also want to set the protocol explicitly. The supported values
 are:
 
 - `OtlpProtocol.Grpc`: Sends a protobuf representation of the 
-   OpenTelemetry Logs over a gRPC connection.
+   OpenTelemetry Logs over a gRPC connection (the default).
 - `OtlpProtocol.HttpProtobuf`: Sends a protobuf representation of the
    OpenTelemetry Logs over an HTTP connection.
 
-Sending OpenTelemetry logs as a JSON payload is not currently supported. 
+When the `OtlpProtocol.HttpProtobuf` option is specified, the endpoint
+URL **must** include the full path, for example `http://localhost:4318/v1/logs`.
 
 ### Resource attributes
 
@@ -116,7 +115,7 @@ the logger is configured.
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(options =>
     {
-        options.Endpoint = "http://127.0.0.1:4317/v1/logs";
+        options.Endpoint = "http://127.0.0.1:4317";
         options.ResourceAttributes = new Dictionary<string, object>
         {
             ["service.name"] = "test-logging-service",
@@ -157,14 +156,14 @@ the Serilog `LogEvent` and .NET `Activity` context via the `IncludedData` flags 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(options =>
     {
-        options.Endpoint = "http://127.0.0.1:4317/v1/logs";
+        options.Endpoint = "http://127.0.0.1:4317";
         options.IncludedData: IncludedData.MessageTemplate |
                               IncludedData.TraceId | IncludedData.SpanId;
     })
     .CreateLogger();
 ```
 
-The example shows the default value; `IncludedData.MessageTemplateMD5HashAttribute` can
+The example shows the default value; `IncludedData.MessageTemplateMD5HashAttribute`~~~~ can
 also be used to add the MD5 hash of the message template.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ inline configuration looks like:
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(
         endpoint: "http://127.0.0.1:4317/v1/logs",
-        protocol: OtlpProtocol.GrpcProtobuf)
+        protocol: OtlpProtocol.Grpc)
     .CreateLogger();
 ```
 
@@ -87,7 +87,7 @@ must be the **full** URL to an OTLP/gRPC endpoint.
 You may also want to set the protocol explicitly. The supported values
 are:
 
-- `OtlpProtocol.GrpcProtobuf`: Sends a protobuf representation of the 
+- `OtlpProtocol.Grpc`: Sends a protobuf representation of the 
    OpenTelemetry Logs over a gRPC connection.
 - `OtlpProtocol.HttpProtobuf`: Sends a protobuf representation of the
    OpenTelemetry Logs over an HTTP connection.

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -80,8 +80,9 @@ static class Program
 
     static ILogger GetLogger(OtlpProtocol protocol)
     {
-        var port = protocol == OtlpProtocol.HttpProtobuf ? 4318 : 4317;
-        var endpoint = $"http://localhost:{port}/v1/logs";
+        var endpoint = protocol == OtlpProtocol.HttpProtobuf ?
+            "http://localhost:4318/v1/logs" :
+            "http://localhost:4317";
 
         return new LoggerConfiguration()
             .MinimumLevel.Information()

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -46,7 +46,7 @@ static class Program
 
         using (source.StartActivity("grpc-loop"))
         {
-            SendLogs(grpcLogger, "grpc/protobuf");
+            SendLogs(grpcLogger, "grpc");
         }
 
         using (source.StartActivity("http-loop"))

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -41,7 +41,7 @@ static class Program
         var source = new ActivitySource("test.example", "1.0.0");
 
         // Create the loggers to send to gRPC and to HTTP.
-        var grpcLogger = GetLogger(OtlpProtocol.GrpcProtobuf);
+        var grpcLogger = GetLogger(OtlpProtocol.Grpc);
         var httpLogger = GetLogger(OtlpProtocol.HttpProtobuf);
 
         using (source.StartActivity("grpc-loop"))

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -42,7 +42,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
         _exporter = protocol switch
         {
             OtlpProtocol.HttpProtobuf => new HttpExporter(endpoint, headers, httpMessageHandler),
-            OtlpProtocol.GrpcProtobuf => new GrpcExporter(endpoint, headers, httpMessageHandler),
+            OtlpProtocol.Grpc => new GrpcExporter(endpoint, headers, httpMessageHandler),
             _ => throw new NotSupportedException($"OTLP protocol {protocol} is unsupported.")
         };
 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.OpenTelemetry;
 public class OpenTelemetrySinkOptions
 {
     internal const string DefaultEndpoint = "http://localhost:4317/v1/logs";
-    internal const OtlpProtocol DefaultProtocol = OtlpProtocol.GrpcProtobuf;
+    internal const OtlpProtocol DefaultProtocol = OtlpProtocol.Grpc;
 
     const IncludedData DefaultIncludedData = IncludedData.MessageTemplateTextAttribute |
                                              IncludedData.TraceIdField | IncludedData.SpanIdField;

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -24,7 +24,7 @@ namespace Serilog.Sinks.OpenTelemetry;
 /// </summary>
 public class OpenTelemetrySinkOptions
 {
-    internal const string DefaultEndpoint = "http://localhost:4317/v1/logs";
+    internal const string DefaultEndpoint = "http://localhost:4317";
     internal const OtlpProtocol DefaultProtocol = OtlpProtocol.Grpc;
 
     const IncludedData DefaultIncludedData = IncludedData.MessageTemplateTextAttribute |

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpProtocol.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpProtocol.cs
@@ -22,7 +22,7 @@ public enum OtlpProtocol
     /// <summary>
     /// Sends OpenTelemetry data encoded as a protobuf message over gRPC.
     /// </summary>
-    GrpcProtobuf,
+    Grpc,
 
     /// <summary>
     /// Posts OpenTelemetry data encoded as a protobuf message over HTTP.

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.OpenTelemetry
     }
     public enum OtlpProtocol
     {
-        GrpcProtobuf = 0,
+        Grpc = 0,
         HttpProtobuf = 1,
     }
 }


### PR DESCRIPTION
Though technically correct, gRPC _only_ supports protocol buffers, so the added word in this identifier is redundant (the default OpenTelelemetry exporter for .NET calls this option `Grpc`). It seems like a small but worthwhile change for us to make before shipping.

I've also lopped the URL path off of the gRPC endpoint examples shown in the README and in the default sink configuration. The sink actually ignores the path in gRPC mode (deep inside the gRPC infrastructure) and uses a different path for gRPC requests. If you sniff it out, you'll find that in gRPC mode, the sink posts to `/opentelemetry.proto.collector.logs.v1.LogsService/Export`.

The full path is very much required when using `HttpProtobuf`, however - I've updated a couple of examples to show this.