### PR TITLE
Set `ObservedTimeUnixNano` to `TimeUnixNano`

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
@@ -67,6 +67,7 @@ static class LogRecordBuilder
     public static void ProcessTimestamp(LogRecord logRecord, LogEvent logEvent)
     {
         logRecord.TimeUnixNano = PrimitiveConversions.ToUnixNano(logEvent.Timestamp);
+        logRecord.ObservedTimeUnixNano = logRecord.TimeUnixNano;
     }
 
     public static void ProcessException(LogRecord logRecord, LogEvent logEvent)

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
@@ -81,6 +81,7 @@ public class LogRecordBuilderTests
         LogRecordBuilder.ProcessTimestamp(logRecord, logEvent);
 
         Assert.Equal(nowNano, logRecord.TimeUnixNano);
+        Assert.Equal(nowNano, logRecord.ObservedTimeUnixNano);
     }
 
     [Fact]


### PR DESCRIPTION
This field exists as a surrogate timestamp when the originating event's timestamp can't be precisely known.

While the field is optional, it will generally be set when passing through other collection infrastructure. Giving it a precise value is a cheap way to ensure that receivers assuming a non-zero value will work as expected.