### PR TITLE
Drop unused `Grpc.Core` dependency

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -25,7 +25,6 @@
 	<ItemGroup>
 		<None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="" />
 		<PackageReference Include="Google.Protobuf" Version="3.21.11" />
-		<PackageReference Include="Grpc" Version="2.46.5" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
 		<PackageReference Include="Serilog" Version="2.12.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />


### PR DESCRIPTION
This package is essentially obsolete - `Grpc.Net.Client` has all we need, and no unmanaged dependencies.