### PR TITLE
Fix `telemetry_sdk.version` - should not include prerelease suffix

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -12,26 +12,20 @@ if(Test-Path .\artifacts) {
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
 $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "main" -and $revision -ne "local"]
-$commitHash = $(git rev-parse --short HEAD)
-$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
 Write-Output "build: Package version suffix is $suffix"
-Write-Output "build: Build version suffix is $buildSuffix"
 
 foreach ($src in Get-ChildItem src/*) {
     Push-Location $src
 
 	Write-Output "build: Packaging project in $src"
 
-    & dotnet build -c Release --version-suffix=$buildSuffix
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
-
-    if($suffix) {
-        & dotnet pack -c Release --include-source --no-build -o ../../artifacts --version-suffix=$suffix
+    if ($suffix) {
+        & dotnet pack -c Release --include-source -o ../../artifacts --version-suffix=$suffix
     } else {
-        & dotnet pack -c Release --include-source --no-build -o ../../artifacts
+        & dotnet pack -c Release --include-source -o ../../artifacts
     }
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
+    if($LASTEXITCODE -ne 0) { throw "Packaging failed" }
 
     Pop-Location
 }
@@ -42,18 +36,7 @@ foreach ($test in Get-ChildItem test/*.Tests) {
 	Write-Output "build: Testing project in $test"
 
     & dotnet test -c Release
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
-
-    Pop-Location
-}
-
-foreach ($test in ls test/*.PerformanceTests) {
-    Push-Location $test
-
-	Write-Output "build: Building performance test project in $test"
-
-    & dotnet build -c Release
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
+    if($LASTEXITCODE -ne 0) { throw "Testing failed" }
 
     Pop-Location
 }


### PR DESCRIPTION
We derive `telemetry_sdk.version` from `AssemblyInformationalVersion`.

On `main`, this needs to be a plain, un-suffixed version, since the presence of a suffix indicates a prerelease package in SemVer.

Today, `telemetry_sdk.version` is being reported from _Serilog.Sinks.OpenTelemetry_ 1.0.0 as in:

![image](https://github.com/serilog/serilog-sinks-opentelemetry/assets/342712/ebd62d74-d088-46ff-a258-a9a15fa2664c)

This PR drops version suffixing on `main` so that the value reported will be simply `1.0.1`, etc.