### PR TITLE
1.0.1 Release

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -12,26 +12,20 @@ if(Test-Path .\artifacts) {
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
 $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "main" -and $revision -ne "local"]
-$commitHash = $(git rev-parse --short HEAD)
-$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
 Write-Output "build: Package version suffix is $suffix"
-Write-Output "build: Build version suffix is $buildSuffix"
 
 foreach ($src in Get-ChildItem src/*) {
     Push-Location $src
 
 	Write-Output "build: Packaging project in $src"
 
-    & dotnet build -c Release --version-suffix=$buildSuffix
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
-
-    if($suffix) {
-        & dotnet pack -c Release --include-source --no-build -o ../../artifacts --version-suffix=$suffix
+    if ($suffix) {
+        & dotnet pack -c Release --include-source -o ../../artifacts --version-suffix=$suffix
     } else {
-        & dotnet pack -c Release --include-source --no-build -o ../../artifacts
+        & dotnet pack -c Release --include-source -o ../../artifacts
     }
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
+    if($LASTEXITCODE -ne 0) { throw "Packaging failed" }
 
     Pop-Location
 }
@@ -42,18 +36,7 @@ foreach ($test in Get-ChildItem test/*.Tests) {
 	Write-Output "build: Testing project in $test"
 
     & dotnet test -c Release
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
-
-    Pop-Location
-}
-
-foreach ($test in ls test/*.PerformanceTests) {
-    Push-Location $test
-
-	Write-Output "build: Building performance test project in $test"
-
-    & dotnet build -c Release
-    if($LASTEXITCODE -ne 0) { throw "Failed" }
+    if($LASTEXITCODE -ne 0) { throw "Testing failed" }
 
     Pop-Location
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Serilog.Sinks.OpenTelemetry [![Build status](https://ci.appveyor.com/api/projects/status/sqmrvw34pcuatwl5/branch/dev?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-opentelemetry/branch/dev) [![NuGet Version](http://img.shields.io/nuget/vpre/Serilog.Sinks.OpenTelemetry.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.OpenTelemetry/)
 
-This Serilog sink will transform Serilog events into OpenTelemetry
-`LogRecord`s and send them as a protobuf payload to an OpenTelemetry
-OTLP (gRPC or HTTP) endpoint.
+This Serilog sink transforms Serilog events into OpenTelemetry
+`LogRecord`s and sends them to an OTLP (gRPC or HTTP) endpoint.
 
 The sink aims for full compliance with the OpenTelemetry Logs protocol. It
 does not depend on the OpenTelemetry SDK or .NET API.
@@ -11,10 +10,7 @@ OpenTelemetry supports attributes with scalar values, arrays, and maps.
 Serilog does as well. Consequently, the sink does a one-to-one
 mapping between Serilog properties and OpenTelemetry attributes.
 There is no flattening, renaming, or other modifications done to the
-properies by default.
-
-The formatter renders the log message, which is then stored as the
-body of the OpenTelemetry `LogRecord`.
+properties by default.
 
 ## Getting started
 

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
+		<Description>This Serilog sink transforms Serilog events into OpenTelemetry
+			logs and sends them to an OTLP (gRPC or HTTP) endpoint.</Description>
 		<VersionPrefix>1.0.1</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -13,6 +13,7 @@
 		<RepositoryType>git</RepositoryType>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<RootNamespace>Serilog</RootNamespace>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
@@ -24,7 +25,8 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="" />
+		<None Include="../../assets/serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
+		<None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
 		<PackageReference Include="Google.Protobuf" Version="3.21.11" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
 		<PackageReference Include="Serilog" Version="2.12.0" />

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>A Serilog sink that writes log events to an OpenTelemetry collector.</Description>
-		<VersionPrefix>1.0.0</VersionPrefix>
+		<VersionPrefix>1.0.1</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 		<PackageTags>serilog;sink;opentelemetry</PackageTags>


### PR DESCRIPTION
 * #91 - include README in package for display on nuget.org (@nblumhardt)
 * #90 - line up package description with README text
 * #92 - don't include prerelease suffix in non-prerelease `telemetry_sdk.version` attribute values (@nblumhardt)