### PR TITLE
Add `IncludedData.MessageTemplateRenderingsAttribute`

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
@@ -71,5 +71,10 @@ public enum IncludedData
     /// })
     /// </code>
     /// </remarks>
-    TemplateBody = 32
+    TemplateBody = 32,
+        
+    /// <summary>
+    /// Include pre-rendered values for any message template placeholders that use custom format specifiers, in <c>message_template.renderings</c>.
+    /// </summary>
+    MessageTemplateRenderingsAttribute = 64
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/LogRecordBuilder.cs
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ReSharper disable PossibleMultipleEnumeration
+
+using System.Globalization;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using Serilog.Events;
+using Serilog.Parsing;
 using Serilog.Sinks.OpenTelemetry.Formatting;
 using Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
 
@@ -136,6 +140,30 @@ static class LogRecordBuilder
             {
                 StringValue = PrimitiveConversions.Md5Hash(logEvent.MessageTemplate.Text)
             }));
+        }
+
+        if ((includedFields & IncludedData.MessageTemplateRenderingsAttribute) != IncludedData.None)
+        {
+            var tokensWithFormat = logEvent.MessageTemplate.Tokens
+                .OfType<PropertyToken>()
+                .Where(pt => pt.Format != null);
+
+            // Better not to allocate an array in the 99.9% of cases where this is false
+            if (tokensWithFormat.Any())
+            {
+                var renderings = new ArrayValue();
+
+                foreach (var propertyToken in tokensWithFormat)
+                {
+                    var space = new StringWriter();
+                    propertyToken.Render(logEvent.Properties, space, CultureInfo.InvariantCulture);
+                    renderings.Values.Add(new AnyValue { StringValue = space.ToString() });
+                }
+                
+                logRecord.Attributes.Add(PrimitiveConversions.NewAttribute(
+                    SemanticConventions.AttributeMessageTemplateRenderings,
+                    new AnyValue { ArrayValue = renderings }));
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/SemanticConventions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/SemanticConventions.cs
@@ -32,6 +32,11 @@ static class SemanticConventions
     public const string AttributeMessageTemplateMD5Hash = "message_template.hash.md5";
 
     /// <summary>
+    /// If any placeholders in the message template use custom format specifiers, an array containing a pre-rendered string for each such token.
+    /// </summary>
+    public const string AttributeMessageTemplateRenderings = "message_template.renderings";
+
+    /// <summary>
     /// OpenTelemetry standard service name resource attribute.
     /// </summary>
     public const string AttributeServiceName = "service.name";

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
@@ -161,11 +161,9 @@ public class LogRecordBuilderTests
     [Fact]
     public void IncludeTraceIdAndSpanId()
     {
-        using var listener = new ActivityListener
-        {
-            ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-        };
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = _ => true;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
 
         ActivitySource.AddActivityListener(listener);
 
@@ -187,11 +185,59 @@ public class LogRecordBuilderTests
     [Fact]
     public void TemplateBodyIncludesMessageTemplateInBody()
     {
-        var messageTemplate = "Hello, {Name}";
+        const string messageTemplate = "Hello, {Name}";
         var properties = new List<LogEventProperty> { new("Name", new ScalarValue("World")) };
 
         var logRecord = LogRecordBuilder.ToLogRecord(Some.SerilogEvent(messageTemplate, properties), null, IncludedData.TemplateBody, new());
         Assert.NotNull(logRecord.Body);
         Assert.Equal(messageTemplate, logRecord.Body.StringValue);
+    }
+    
+    [Fact]
+    public void NoRenderingsIncludedWhenNoneInTemplate()
+    {
+        var logEvent = Some.SerilogEvent(messageTemplate: "Hello, {Name}", properties: new [] { new LogEventProperty("Name", new ScalarValue("World"))});
+        
+        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute, new());
+        
+        Assert.DoesNotContain(SemanticConventions.AttributeMessageTemplateRenderings, logRecord.Attributes.Select(a => a.Key));
+    }
+    
+    [Fact]
+    public void RenderingsIncludedWhenPresentInTemplate()
+    {
+        var logEvent = Some.SerilogEvent(messageTemplate: "{First:0} {Second} {Third:0.00}", properties: new []
+        {
+            new LogEventProperty("First", new ScalarValue(123.456)),
+            new LogEventProperty("Second", new ScalarValue(234.567)),
+            new LogEventProperty("Third", new ScalarValue(345.678))
+        });
+        
+        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute, new());
+        
+        var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateRenderings, Value = new()
+        {
+            ArrayValue = new ArrayValue {
+                Values =
+                {
+                    // Only values for tokens with format strings are included.
+                    new AnyValue{ StringValue = "123"},
+                    new AnyValue{ StringValue = "345.68"},
+                }
+            }
+        }};
+        Assert.Contains(expectedAttribute, logRecord.Attributes);
+    }
+    
+    [Fact]
+    public void RenderingsNotIncludedWhenIncludedDataDoesNotSpecifyThem()
+    {
+        var logEvent = Some.SerilogEvent(messageTemplate: "{First:0}", properties: new []
+        {
+            new LogEventProperty("First", new ScalarValue(123.456))
+        });
+        
+        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, OpenTelemetrySinkOptions.DefaultIncludedData, new());
+        Assert.DoesNotContain(SemanticConventions.AttributeMessageTemplateRenderings, logRecord.Attributes.Select(a => a.Key));
     }
 }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -25,6 +25,7 @@ namespace Serilog.Sinks.OpenTelemetry
         SpanIdField = 8,
         SpecRequiredResourceAttributes = 16,
         TemplateBody = 32,
+        MessageTemplateRenderingsAttribute = 64,
     }
     public class OpenTelemetrySinkOptions
     {


### PR DESCRIPTION
Given the log event produced by:

```csharp
Log.Information("Processed in {Elapsed:0.000} seconds", 12.3456);
```

the message template will be `"Processed in {Elapsed:0.000} seconds"` and the `Elapsed` attribute will contain `12.3456`.

This unfortunately isn't enough information for a receiver to correctly render the template. Receivers aren't always written in .NET (so can't deal with .NET format strings) and the original data type may not even be well-known/meaningful to the receiver.

To deal with this, _Serilog.Formatting.Compact_ includes a _renderings_ array in the payload of any event that contains format specifiers in its message template. For the above example this would look like:

```
{
    "@r":["12.346"],
    ...
```

A reader/receiver can then used the pre-rendered version of the property to faithfully reproduce the rendered message, without needing the entire message to be rendered in the payload. Seq and _Serilog.Formatting.Compact.Reader_-based tools take advantage of this today.

This PR implements an opt-in `IncludedData.MessageTemplateRenderingsAttribute` flag do to the same thing here, via the `message_template.renderings` attribute.

The new flag works quite nicely alongside the recently-added [`IncludedData.TemplateBody` option](#104) - used together, they preserve 100% of the template formatting without requiring a fully-formatted message. It might therefore be nice to get this into #105.