### PR TITLE
Preserve full 100-nanosecond timestamp resolution when converting to Unix nanos

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -26,11 +26,13 @@ namespace Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
 
 static class PrimitiveConversions
 {
-    const ulong MillisToNanos = 1000000;
-
-    public static ulong ToUnixNano(DateTimeOffset t)
+    static readonly DateTimeOffset UnixEpoch = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    
+    public static ulong ToUnixNano(DateTimeOffset dateTimeOffset)
     {
-        return (ulong)t.ToUnixTimeMilliseconds() * MillisToNanos;
+        if (dateTimeOffset < UnixEpoch) throw new ArgumentOutOfRangeException(nameof(dateTimeOffset));
+        var timeSinceEpoch = dateTimeOffset - UnixEpoch;
+        return (ulong)timeSinceEpoch.Ticks * 100;
     }
 
     public static SeverityNumber ToSeverityNumber(LogEventLevel level)

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -41,7 +41,6 @@ static class PrimitiveConversions
         {
             LogEventLevel.Verbose => SeverityNumber.Trace,
             LogEventLevel.Debug => SeverityNumber.Debug,
-            LogEventLevel.Information => SeverityNumber.Info,
             LogEventLevel.Warning => SeverityNumber.Warn,
             LogEventLevel.Error => SeverityNumber.Error,
             LogEventLevel.Fatal => SeverityNumber.Fatal,

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -41,6 +41,7 @@ static class PrimitiveConversions
         {
             LogEventLevel.Verbose => SeverityNumber.Trace,
             LogEventLevel.Debug => SeverityNumber.Debug,
+            LogEventLevel.Information => SeverityNumber.Info,
             LogEventLevel.Warning => SeverityNumber.Warn,
             LogEventLevel.Error => SeverityNumber.Error,
             LogEventLevel.Fatal => SeverityNumber.Fatal,

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PrimitiveConversionsTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PrimitiveConversionsTests.cs
@@ -42,12 +42,20 @@ public class PrimitiveConversionsTests
         var t0 = DateTimeOffset.UtcNow;
         var nanos = (ulong)t0.ToUnixTimeMilliseconds() * 1000000;
         var actual = PrimitiveConversions.ToUnixNano(t0);
-        Assert.Equal(nanos, PrimitiveConversions.ToUnixNano(t0));
+        Assert.Equal(nanos, actual);
 
         // later time has different (greater) value
         Thread.Sleep(1000);
         var t1 = DateTimeOffset.UtcNow;
         Assert.True(PrimitiveConversions.ToUnixNano(t1) > nanos);
+    }
+
+    [Fact]
+    public void UnixEpochTimePreservesResolution()
+    {
+        var tOneHundredNanos = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero).AddTicks(1);
+        var actual = PrimitiveConversions.ToUnixNano(tOneHundredNanos);
+        Assert.Equal(100ul, actual);
     }
 
     [Fact]
@@ -63,7 +71,7 @@ public class PrimitiveConversionsTests
             {LogEventLevel.Fatal, SeverityNumber.Fatal},
         };
 
-        foreach ((var level, var severity) in data)
+        foreach (var (level, severity) in data)
         {
             Assert.Equal(severity, PrimitiveConversions.ToSeverityNumber(level));
         }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PrimitiveConversionsTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PrimitiveConversionsTests.cs
@@ -38,16 +38,9 @@ public class PrimitiveConversionsTests
     [Fact]
     public void TestToUnixNano()
     {
-        // current time has expected value
-        var t0 = DateTimeOffset.UtcNow;
-        var nanos = (ulong)t0.ToUnixTimeMilliseconds() * 1000000;
-        var actual = PrimitiveConversions.ToUnixNano(t0);
-        Assert.Equal(nanos, actual);
-
-        // later time has different (greater) value
-        Thread.Sleep(1000);
-        var t1 = DateTimeOffset.UtcNow;
-        Assert.True(PrimitiveConversions.ToUnixNano(t1) > nanos);
+        var t = DateTimeOffset.Parse("2023-10-09T07:00:38.7998331+00:00");
+        var actual = PrimitiveConversions.ToUnixNano(t);
+        Assert.Equal(1696834838799833100ul, actual);
     }
 
     [Fact]


### PR DESCRIPTION
The previous algorithm only maintains millisecond resolution.