### PR TITLE
Use `SourceContext` to populate `InstrumentationScope.Name`

### DIFF
--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -14,8 +14,6 @@
 
 // ReSharper disable ExplicitCallerInfoArgument
 
-#nullable enable
-
 using Serilog;
 using System.Diagnostics;
 using Serilog.Sinks.OpenTelemetry;
@@ -30,11 +28,9 @@ static class Program
     {
         // create an ActivitySource (that is listened to) for creating an Activity
         // to test the trace and span ID enricher
-        using var listener = new ActivityListener
-        {
-            ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-        };
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = _ => true;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
 
         ActivitySource.AddActivityListener(listener);
 

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -14,6 +14,7 @@
 
 using Serilog.Configuration;
 using Serilog.Sinks.OpenTelemetry;
+using Serilog.Sinks.OpenTelemetry.Exporters;
 using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog;
@@ -39,14 +40,17 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         var options = new BatchedOpenTelemetrySinkOptions();
         configure(options);
 
-        var openTelemetrySink = new OpenTelemetrySink(
+        var exporter = Exporter.Create(
             endpoint: options.Endpoint,
             protocol: options.Protocol,
+            headers: new Dictionary<string, string>(options.Headers),
+            httpMessageHandler: options.HttpMessageHandler);
+
+        var openTelemetrySink = new OpenTelemetrySink(
+            exporter: exporter,
             formatProvider: options.FormatProvider,
             resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
-            headers: new Dictionary<string, string>(options.Headers),
-            includedData: options.IncludedData,
-            httpMessageHandler: options.HttpMessageHandler);
+            includedData: options.IncludedData);
 
         var sink = new PeriodicBatchingSink(openTelemetrySink, options.BatchingOptions);
 
@@ -97,14 +101,17 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         
         configure(options);
 
-        var sink = new OpenTelemetrySink(
+        var exporter = Exporter.Create(
             endpoint: options.Endpoint,
             protocol: options.Protocol,
+            headers: new Dictionary<string, string>(options.Headers),
+            httpMessageHandler: options.HttpMessageHandler);
+
+        var sink = new OpenTelemetrySink(
+            exporter: exporter,
             formatProvider: options.FormatProvider,
             resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
-            headers: new Dictionary<string, string>(options.Headers),
-            includedData: options.IncludedData,
-            httpMessageHandler: options.HttpMessageHandler);
+            includedData: options.IncludedData);
 
         return loggerAuditSinkConfiguration.Sink(sink, options.RestrictedToMinimumLevel, options.LevelSwitch);
     }

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<Description>This Serilog sink transforms Serilog events into OpenTelemetry
 			logs and sends them to an OTLP (gRPC or HTTP) endpoint.</Description>
-		<VersionPrefix>1.2.0</VersionPrefix>
+		<VersionPrefix>2.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
 		<PackageTags>serilog;sink;opentelemetry</PackageTags>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/Exporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/Exporter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2022 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Serilog.Sinks.OpenTelemetry.Exporters;
+
+static class Exporter
+{
+    public static IExporter Create(
+        string endpoint,
+        OtlpProtocol protocol,
+        IReadOnlyDictionary<string, string> headers,
+        HttpMessageHandler? httpMessageHandler)
+    {
+        return protocol switch
+        {
+            OtlpProtocol.HttpProtobuf => new HttpExporter(endpoint, headers, httpMessageHandler),
+            OtlpProtocol.Grpc => new GrpcExporter(endpoint, headers, httpMessageHandler),
+            _ => throw new NotSupportedException($"OTLP protocol {protocol} is unsupported.")
+        };
+    }
+}

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/GrpcExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/GrpcExporter.cs
@@ -16,7 +16,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 
-namespace Serilog.Sinks.OpenTelemetry;
+namespace Serilog.Sinks.OpenTelemetry.Exporters;
 
 /// <summary>
 /// Implements an IExporter that sends OpenTelemetry Log requests

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
@@ -15,7 +15,7 @@
 using Google.Protobuf;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 
-namespace Serilog.Sinks.OpenTelemetry;
+namespace Serilog.Sinks.OpenTelemetry.Exporters;
 
 /// <summary>
 /// Implements an IExporter that sends OpenTelemetry Log requests

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
@@ -76,5 +76,11 @@ public enum IncludedData
     /// <summary>
     /// Include pre-rendered values for any message template placeholders that use custom format specifiers, in <c>message_template.renderings</c>.
     /// </summary>
-    MessageTemplateRenderingsAttribute = 64
+    MessageTemplateRenderingsAttribute = 64,
+    
+    /// <summary>
+    /// Preserve the value of the <c>SourceContext</c> property, in addition to using it as the OTLP <c>InstrumentationScope</c> name. If
+    /// not specified, the <c>SourceContext</c> property will be omitted from the individual log record attributes.
+    /// </summary>
+    SourceContextAttribute = 128
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -29,21 +29,12 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
     readonly IncludedData _includedData;
 
     public OpenTelemetrySink(
-       string endpoint,
-       OtlpProtocol protocol,
-       IFormatProvider? formatProvider,
-       IReadOnlyDictionary<string, object> resourceAttributes,
-       IReadOnlyDictionary<string, string> headers,
-       IncludedData includedData,
-       HttpMessageHandler? httpMessageHandler) 
+        IExporter exporter,
+        IFormatProvider? formatProvider,
+        IReadOnlyDictionary<string, object> resourceAttributes,
+        IncludedData includedData)
     {
-        _exporter = protocol switch
-        {
-            OtlpProtocol.HttpProtobuf => new HttpExporter(endpoint, headers, httpMessageHandler),
-            OtlpProtocol.Grpc => new GrpcExporter(endpoint, headers, httpMessageHandler),
-            _ => throw new NotSupportedException($"OTLP protocol {protocol} is unsupported.")
-        };
-
+        _exporter = exporter;
         _formatProvider = formatProvider;
         _includedData = includedData;
 
@@ -93,6 +84,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
                 if (!namedScopes.TryGetValue(scopeName, out var namedScope))
                 {
                     namedScope = RequestTemplateFactory.CreateScopeLogs(scopeName);
+                    namedScopes.Add(scopeName, namedScope);
                     resourceLogs.ScopeLogs.Add(namedScope);
                 }
                 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using OpenTelemetry.Proto.Collector.Logs.V1;
+using OpenTelemetry.Proto.Logs.V1;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
@@ -23,7 +24,7 @@ namespace Serilog.Sinks.OpenTelemetry;
 class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
 {
     readonly IFormatProvider? _formatProvider;
-    readonly ExportLogsServiceRequest _requestTemplate;
+    readonly ResourceLogs _resourceLogsTemplate;
     readonly IExporter _exporter;
     readonly IncludedData _includedData;
 
@@ -51,7 +52,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
             resourceAttributes = RequiredResourceAttributes.AddDefaults(resourceAttributes);
         }
 
-        _requestTemplate = RequestTemplateFactory.CreateRequestTemplate(resourceAttributes);
+        _resourceLogsTemplate = RequestTemplateFactory.CreateResourceLogs(resourceAttributes);
     }
 
     /// <summary>
@@ -62,25 +63,46 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
         (_exporter as IDisposable)?.Dispose();
     }
 
-    void AddLogEventToRequest(LogEvent logEvent, ExportLogsServiceRequest request)
-    {
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, _formatProvider, _includedData);
-        request.ResourceLogs[0].ScopeLogs[0].LogRecords.Add(logRecord);
-    }
-
     /// <summary>
     /// Transforms and sends the given batch of LogEvent objects
     /// to an OTLP endpoint.
     /// </summary>
     public Task EmitBatchAsync(IEnumerable<LogEvent> batch)
     {
-        var request = _requestTemplate.Clone();
+        var resourceLogs = _resourceLogsTemplate.Clone();
+        
+        var anonymousScope = (ScopeLogs?)null;
+        var namedScopes = (Dictionary<string, ScopeLogs>?)null;
 
         foreach (var logEvent in batch)
         {
-            AddLogEventToRequest(logEvent, request);
+            var (logRecord, scopeName) = LogRecordBuilder.ToLogRecord(logEvent, _formatProvider, _includedData);
+            if (scopeName == null)
+            {
+                if (anonymousScope == null)
+                {
+                    anonymousScope = RequestTemplateFactory.CreateScopeLogs(null);
+                    resourceLogs.ScopeLogs.Add(anonymousScope);
+                }
+                
+                anonymousScope.LogRecords.Add(logRecord);
+            }
+            else
+            {
+                namedScopes ??= new Dictionary<string, ScopeLogs>();
+                if (!namedScopes.TryGetValue(scopeName, out var namedScope))
+                {
+                    namedScope = RequestTemplateFactory.CreateScopeLogs(scopeName);
+                    resourceLogs.ScopeLogs.Add(namedScope);
+                }
+                
+                namedScope.LogRecords.Add(logRecord);
+            }
         }
 
+        var request = new ExportLogsServiceRequest();
+        request.ResourceLogs.Add(resourceLogs);
+        
         return _exporter.ExportAsync(request);
     }
 
@@ -90,8 +112,13 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
     /// </summary>
     public void Emit(LogEvent logEvent)
     {
-        var request = _requestTemplate.Clone();
-        AddLogEventToRequest(logEvent, request);
+        var (logRecord, scopeName) = LogRecordBuilder.ToLogRecord(logEvent, _formatProvider, _includedData);
+        var scopeLogs = RequestTemplateFactory.CreateScopeLogs(scopeName);
+        scopeLogs.LogRecords.Add(logRecord);
+        var resourceLogs = _resourceLogsTemplate.Clone();
+        resourceLogs.ScopeLogs.Add(scopeLogs);
+        var request = new ExportLogsServiceRequest();
+        request.ResourceLogs.Add(resourceLogs);
         _exporter.Export(request);
     }
 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PackageIdentity.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PackageIdentity.cs
@@ -18,21 +18,12 @@ namespace Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
 
 static class PackageIdentity
 {
-    public static string GetInstrumentationScopeName()
-    {
-        return typeof(RequestTemplateFactory).Assembly.GetName().Name
-               // Best we know about this, if it occurs.
-               ?? throw new InvalidOperationException("Sink assembly name could not be retrieved.");
-    }
-
-    public static string GetInstrumentationScopeVersion()
+    public static string GetTelemetrySdkVersion()
     {
         return typeof(RequestTemplateFactory).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
     }
 
     public const string TelemetrySdkName = "serilog";
     
-    public static string GetTelemetrySdkVersion() => GetInstrumentationScopeVersion();
-
     public const string TelemetrySdkLanguage = "dotnet";
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/RequestTemplateFactory.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/RequestTemplateFactory.cs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Reflection;
 using Google.Protobuf.Collections;
-using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Resource.V1;

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/RequestTemplateFactory.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/RequestTemplateFactory.cs
@@ -25,29 +25,20 @@ static class RequestTemplateFactory
 {
     const string OpenTelemetrySchemaUrl = "https://opentelemetry.io/schemas/v1.13.0";
     
-    public static ExportLogsServiceRequest CreateRequestTemplate(IReadOnlyDictionary<string, object> resourceAttributes)
+    public static ScopeLogs CreateScopeLogs(string? scopeName)
     {
-        var resourceLogs = CreateResourceLogs(resourceAttributes);
-        resourceLogs.ScopeLogs.Add(CreateEmptyScopeLogs());
-
-        var request = new ExportLogsServiceRequest();
-        request.ResourceLogs.Add(resourceLogs);
-
-        return request;
-    }
-    
-    static InstrumentationScope CreateInstrumentationScope()
-    {
-        var scope = new InstrumentationScope
+        var scope = scopeName != null ? new InstrumentationScope
         {
-            Name = PackageIdentity.GetInstrumentationScopeName(),
-            Version = PackageIdentity.GetInstrumentationScopeVersion()
-        };
+            Name = scopeName,
+        } : null;
 
-        return scope;
+        return new ScopeLogs
+        {
+            Scope = scope
+        };
     }
 
-    static ResourceLogs CreateResourceLogs(IReadOnlyDictionary<string, object> resourceAttributes)
+    public static ResourceLogs CreateResourceLogs(IReadOnlyDictionary<string, object> resourceAttributes)
     {
         var resourceLogs = new ResourceLogs();
 
@@ -59,17 +50,6 @@ static class RequestTemplateFactory
         resourceLogs.SchemaUrl = OpenTelemetrySchemaUrl;
 
         return resourceLogs;
-    }
-
-    static ScopeLogs CreateEmptyScopeLogs()
-    {
-        var scopeLogs = new ScopeLogs
-        {
-            Scope = CreateInstrumentationScope(),
-            SchemaUrl = OpenTelemetrySchemaUrl
-        };
-
-        return scopeLogs;
     }
 
     static RepeatedField<KeyValue> ToResourceAttributes(IReadOnlyDictionary<string, object> resourceAttributes)

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/LogRecordBuilderTests.cs
@@ -65,7 +65,7 @@ public class LogRecordBuilderTests
 
         logEvent.AddOrUpdateProperty(prop);
 
-        LogRecordBuilder.ProcessProperties(logRecord, logEvent);
+        LogRecordBuilder.ProcessProperties(logRecord, logEvent, IncludedData.None, out _);
 
         Assert.Contains(propertyKeyValue, logRecord.Attributes);
     }
@@ -122,7 +122,7 @@ public class LogRecordBuilderTests
     {
         var logEvent = Some.SerilogEvent(messageTemplate: Some.TestMessageTemplate);
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateMD5HashAttribute);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateMD5HashAttribute);
         
         var expectedHash = PrimitiveConversions.Md5Hash(Some.TestMessageTemplate);
         var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateMD5Hash, Value = new() { StringValue = expectedHash }};
@@ -137,7 +137,7 @@ public class LogRecordBuilderTests
 
         var logEvent = Some.SerilogEvent(messageTemplate, properties);
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateTextAttribute);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateTextAttribute);
 
         var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateText, Value = new() { StringValue = messageTemplate } };
         Assert.Contains(expectedAttribute, logRecord.Attributes);
@@ -149,7 +149,7 @@ public class LogRecordBuilderTests
         Assert.Null(Activity.Current);
 
         var logEvent = Some.DefaultSerilogEvent();
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.TraceIdField | IncludedData.SpanIdField);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.TraceIdField | IncludedData.SpanIdField);
 
         Assert.True(logRecord.TraceId.IsEmpty);
         Assert.True(logRecord.SpanId.IsEmpty);
@@ -170,7 +170,7 @@ public class LogRecordBuilderTests
 
         var logEvent = CollectingSink.CollectSingle(log => log.Information("Hello, trace and span!"));
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.TraceIdField | IncludedData.SpanIdField);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.TraceIdField | IncludedData.SpanIdField);
 
         Assert.Equal(logRecord.TraceId, PrimitiveConversions.ToOpenTelemetryTraceId(Activity.Current.TraceId.ToHexString()));
         Assert.Equal(logRecord.SpanId, PrimitiveConversions.ToOpenTelemetrySpanId(Activity.Current.SpanId.ToHexString()));
@@ -182,7 +182,7 @@ public class LogRecordBuilderTests
         const string messageTemplate = "Hello, {Name}";
         var properties = new List<LogEventProperty> { new("Name", new ScalarValue("World")) };
 
-        var logRecord = LogRecordBuilder.ToLogRecord(Some.SerilogEvent(messageTemplate, properties), null, IncludedData.TemplateBody);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(Some.SerilogEvent(messageTemplate, properties), null, IncludedData.TemplateBody);
         Assert.NotNull(logRecord.Body);
         Assert.Equal(messageTemplate, logRecord.Body.StringValue);
     }
@@ -192,7 +192,7 @@ public class LogRecordBuilderTests
     {
         var logEvent = Some.SerilogEvent(messageTemplate: "Hello, {Name}", properties: new [] { new LogEventProperty("Name", new ScalarValue("World"))});
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute);
         
         Assert.DoesNotContain(SemanticConventions.AttributeMessageTemplateRenderings, logRecord.Attributes.Select(a => a.Key));
     }
@@ -202,7 +202,7 @@ public class LogRecordBuilderTests
     {
         var logEvent = CollectingSink.CollectSingle(log => log.Information("{First:0} {Second} {Third:0.00}", 123.456, 234.567, 345.678));
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, IncludedData.MessageTemplateRenderingsAttribute);
         
         var expectedAttribute = new KeyValue { Key = SemanticConventions.AttributeMessageTemplateRenderings, Value = new()
         {
@@ -223,7 +223,7 @@ public class LogRecordBuilderTests
     {
         var logEvent = CollectingSink.CollectSingle(log => log.Information("{First:0}", 123.456));
         
-        var logRecord = LogRecordBuilder.ToLogRecord(logEvent, null, OpenTelemetrySinkOptions.DefaultIncludedData);
+        var (logRecord, _) = LogRecordBuilder.ToLogRecord(logEvent, null, OpenTelemetrySinkOptions.DefaultIncludedData);
         
         Assert.DoesNotContain(SemanticConventions.AttributeMessageTemplateRenderings, logRecord.Attributes.Select(a => a.Key));
     }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetrySinkTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetrySinkTests.cs
@@ -1,0 +1,58 @@
+﻿using OpenTelemetry.Proto.Collector.Logs.V1;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.OpenTelemetry.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.OpenTelemetry.Tests;
+
+public class OpenTelemetrySinkTests
+{
+    [Fact]
+    public async Task DefaultScopeIsNull()
+    {
+        var events = CollectingSink.Collect(log => log.Information("Hello, world!"));
+        var request = await ExportAsync(events);
+        var resourceLogs = Assert.Single(request.ResourceLogs);
+        var scopeLogs = Assert.Single(resourceLogs.ScopeLogs);
+        Assert.Null(scopeLogs.Scope);
+    }
+    
+    [Fact]
+    public async Task SourceContextNameIsInstrumentationScope()
+    {
+        var contextType = typeof(LogRecordBuilderTests);
+        var events = CollectingSink.Collect(log => log.ForContext(contextType).Information("Hello, world!"));
+        var request = await ExportAsync(events);
+        var resourceLogs = Assert.Single(request.ResourceLogs);
+        var scopeLogs = Assert.Single(resourceLogs.ScopeLogs);
+        Assert.Equal(contextType.FullName, scopeLogs.Scope.Name);
+    }
+    
+    [Fact]
+    public async Task ScopeLogsAreGrouped()
+    {
+        var events = CollectingSink.Collect(log =>
+        {
+            log.ForContext(Constants.SourceContextPropertyName, "A").Information("Hello, world!");
+            log.ForContext(Constants.SourceContextPropertyName, "B").Information("Hello, world!");
+            log.ForContext(Constants.SourceContextPropertyName, "A").Information("Hello, world!");
+            log.Information("Hello, world!");
+        });
+        var request = await ExportAsync(events);
+        var resourceLogs = Assert.Single(request.ResourceLogs);
+        Assert.Equal(3, resourceLogs.ScopeLogs.Count);
+        Assert.Equal(4, resourceLogs.ScopeLogs.SelectMany(s => s.LogRecords).Count());
+        Assert.Equal(2, resourceLogs.ScopeLogs.Single(r => r.Scope?.Name == "A").LogRecords.Count);
+        Assert.Single(resourceLogs.ScopeLogs.Single(r => r.Scope?.Name == "B").LogRecords);
+        Assert.Single(resourceLogs.ScopeLogs.Single(r => r.Scope == null).LogRecords);
+    }
+
+    static async Task<ExportLogsServiceRequest> ExportAsync(IEnumerable<LogEvent> events)
+    {
+        var exporter = new CollectingExporter();
+        var sink = new OpenTelemetrySink(exporter, null, new Dictionary<string, object>(), OpenTelemetrySinkOptions.DefaultIncludedData);
+        await sink.EmitBatchAsync(events);
+        return Assert.Single(exporter.Requests);
+    }
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -26,6 +26,7 @@ namespace Serilog.Sinks.OpenTelemetry
         SpecRequiredResourceAttributes = 16,
         TemplateBody = 32,
         MessageTemplateRenderingsAttribute = 64,
+        SourceContextAttribute = 128,
     }
     public class OpenTelemetrySinkOptions
     {

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/RequestTemplateFactoryTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/RequestTemplateFactoryTests.cs
@@ -25,19 +25,19 @@ public class RequestTemplateFactoryTests
     {
         var template = RequestTemplateFactory.CreateResourceLogs(new Dictionary<string, object>());
 
-        var request = template.Clone();
+        var clone = template.Clone();
 
-        var n = request.ScopeLogs.Count;
+        var n = clone.ScopeLogs.Count;
         Assert.Equal(0, n);
 
-        request.ScopeLogs.Add(new ScopeLogs());
+        clone.ScopeLogs.Add(new ScopeLogs());
 
-        n = request.ScopeLogs.Count;
+        n = clone.ScopeLogs.Count;
         Assert.Equal(1, n);
         
-        request = template.Clone();
+        clone = template.Clone();
 
-        n = request.ScopeLogs.Count;
+        n = clone.ScopeLogs.Count;
         Assert.Equal(0, n);
     }
 }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/Support/CollectingExporter.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/Support/CollectingExporter.cs
@@ -1,0 +1,19 @@
+﻿using OpenTelemetry.Proto.Collector.Logs.V1;
+
+namespace Serilog.Sinks.OpenTelemetry.Tests.Support;
+
+class CollectingExporter: IExporter
+{
+    public List<ExportLogsServiceRequest> Requests { get; } = new();
+    
+    public void Export(ExportLogsServiceRequest request)
+    {
+        Requests.Add(request);
+    }
+
+    public Task ExportAsync(ExportLogsServiceRequest request)
+    {
+        Export(request);
+        return Task.CompletedTask;
+    }
+}

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/Support/CollectingSink.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/Support/CollectingSink.cs
@@ -15,9 +15,18 @@ class CollectingSink: ILogEventSink
 
     public static LogEvent CollectSingle(Action<ILogger> emitter)
     {
+        return Assert.Single(Collect(emitter));
+    }
+
+    public static IReadOnlyList<LogEvent> Collect(Action<ILogger> emitter)
+    {
         var sink = new CollectingSink();
-        var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
-        emitter(logger);
-        return Assert.Single(sink._emitted);
+        var collector = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        
+        emitter(collector);
+
+        return sink._emitted;
     }
 }


### PR DESCRIPTION
Fixes #112 

This ends up being a breaking change, since the default instrumentation scope changes, and `SourceContext` won't appear as an attribute without the `IncludedData.SourceContextAttribute` option. I've bumped the major version to 2.0.0 to reflect this.