### PR TITLE
Update `Serilog.Sinks.PeriodicBatching` to take advantage of eager sends

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -29,7 +29,7 @@
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
 	</ItemGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -4,7 +4,7 @@
 			logs and sends them to an OTLP (gRPC or HTTP) endpoint.</Description>
 		<VersionPrefix>2.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
 		<PackageTags>serilog;sink;opentelemetry</PackageTags>
 		<PackageIcon>serilog-sink-nuget.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/serilog/serilog-sinks-opentelemetry</PackageProjectUrl>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -17,11 +17,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_CWT_ADDORUPDATE;FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY</DefineConstants>
-	</PropertyGroup>
-	
-	<PropertyGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
-		<DefineConstants>$(DefineConstants);NO_SYNC_HTTP_SEND</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_CWT_ADDORUPDATE;FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY;FEATURE_SYNC_HTTP_SEND</DefineConstants>
 	</PropertyGroup>
 	
 	<ItemGroup>
@@ -30,7 +26,7 @@
 		<PackageReference Include="Google.Protobuf" Version="3.23.4" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
 		<PackageReference Include="Serilog" Version="3.1.1" />
-		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
 	</ItemGroup>
 	
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -4,7 +4,7 @@
 			logs and sends them to an OTLP (gRPC or HTTP) endpoint.</Description>
 		<VersionPrefix>2.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+		<TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
 		<PackageTags>serilog;sink;opentelemetry</PackageTags>
 		<PackageIcon>serilog-sink-nuget.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/serilog/serilog-sinks-opentelemetry</PackageProjectUrl>
@@ -29,7 +29,7 @@
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
 	</ItemGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462' ">
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
@@ -59,11 +59,11 @@ sealed class HttpExporter : IExporter, IDisposable
     {
         var httpRequest = CreateHttpRequestMessage(request);
 
-#if NO_SYNC_HTTP_SEND
-        var response = _client.SendAsync(httpRequest).Result;
-#else
+#if FEATURE_SYNC_HTTP_SEND
         // We could consider using HttpCompletionOption.ResponseHeadersRead here.
         var response = _client.Send(httpRequest);
+#else
+        var response = _client.SendAsync(httpRequest).Result;
 #endif
         
         response.EnsureSuccessStatusCode();

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Exporters/HttpExporter.cs
@@ -60,9 +60,16 @@ sealed class HttpExporter : IExporter, IDisposable
         var httpRequest = CreateHttpRequestMessage(request);
 
 #if FEATURE_SYNC_HTTP_SEND
-        // We could consider using HttpCompletionOption.ResponseHeadersRead here.
+        // Used in audit mode; on later .NET platforms this can be done without the
+        // risk of deadlocks.
+        // FUTURE: We could consider using HttpCompletionOption.ResponseHeadersRead here, but
+        // would need to investigate any potential impacts on receivers.
         var response = _client.Send(httpRequest);
 #else
+        // Earlier .NET: some deadlock risk here. Necessary because in audit mode,
+        // exceptions need to propagate - otherwise we'd just fire-and-forget.
+        // No `ConfigureAwait(false)` because this only applies to async continuations: we're
+        // staying on the same thread, here.
         var response = _client.SendAsync(httpRequest).Result;
 #endif
         


### PR DESCRIPTION
The new _Serilog.Sinks.PeriodicBatching_ is [implemented over _System.Threading.Channels_](https://github.com/serilog/serilog-sinks-periodicbatching/pull/66) and uses a new internal algorithm that sends batches as soon as they're full, rather than waiting for the buffering period to elapse.

Seems enough of an improvement that we'd want to adopt it here, so pulling in the prerelease package to contribute some test cycles :-)