### PR TITLE
Specify a default non-propagating handler on net6.0+

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net.Http;
 using Serilog.Configuration;
 using Serilog.Sinks.OpenTelemetry;
 using Serilog.Sinks.OpenTelemetry.Exporters;
@@ -25,6 +26,13 @@ namespace Serilog;
 /// </summary>
 public static class OpenTelemetryLoggerConfigurationExtensions
 {
+    static HttpMessageHandler? CreateDefaultHttpMessageHandler() =>
+#if FEATURE_SOCKETS_HTTP_HANDLER
+        new SocketsHttpHandler { ActivityHeadersPropagator = null };
+#else
+        null;
+#endif
+    
     /// <summary>
     /// Send log events to an OTLP exporter.
     /// </summary>
@@ -45,7 +53,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             endpoint: options.Endpoint,
             protocol: options.Protocol,
             headers: new Dictionary<string, string>(options.Headers),
-            httpMessageHandler: options.HttpMessageHandler);
+            httpMessageHandler: options.HttpMessageHandler ?? CreateDefaultHttpMessageHandler());
 
         var openTelemetrySink = new OpenTelemetrySink(
             exporter: exporter,
@@ -117,7 +125,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             endpoint: options.Endpoint,
             protocol: options.Protocol,
             headers: new Dictionary<string, string>(options.Headers),
-            httpMessageHandler: options.HttpMessageHandler);
+            httpMessageHandler: options.HttpMessageHandler ?? CreateDefaultHttpMessageHandler());
 
         var sink = new OpenTelemetrySink(
             exporter: exporter,

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_CWT_ADDORUPDATE;FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY;FEATURE_SYNC_HTTP_SEND</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_CWT_ADDORUPDATE;FEATURE_ACTIVITY;FEATURE_HALF;FEATURE_DATE_AND_TIME_ONLY;FEATURE_SYNC_HTTP_SEND;FEATURE_SOCKETS_HTTP_HANDLER</DefineConstants>
 	</PropertyGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
For #41

This PR is a targeted approach to silencing the sink's own request logging by default through a `SocketsHttpHandler` that disables `ActivityHeadersPropagator`. It only applies to .NET 6+ when `SocketsHttpHandler` was introduced. Unsupported targets will need to work around the diagnostic handler in other ways.

This is a low-commitment approach, so it shouldn't prevent us from considering other options in the future too.