### PR TITLE
User Serilog v4's batching implementation, drop `Serilog.Sinks.PeriodicBatching`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,10 @@ version: '{build}'
 skip_tags: true
 image: Visual Studio 2022
 build_script:
-    - pwsh: ./Build.ps1
+    - pwsh: |
+        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"
+        ./dotnet-install.ps1 -JsonFile global.json -Architecture x64 -InstallDir 'C:\Program Files\dotnet'
+        ./Build.ps1
 artifacts:
     - path: artifacts/Serilog.*.nupkg
 deploy:

--- a/example/Example/Example.csproj
+++ b/example/Example/Example.csproj
@@ -2,15 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Sinks.OpenTelemetry\Serilog.Sinks.OpenTelemetry.csproj" />
   </ItemGroup>

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -89,7 +89,7 @@ static Logger CreateLogger(OtlpProtocol protocol)
                 ["Authorization"] = "Basic dXNlcjphYmMxMjM=", // user:abc123
             };
             options.BatchingOptions.BatchSizeLimit = 700;
-            options.BatchingOptions.Period = TimeSpan.FromSeconds(1);
+            options.BatchingOptions.BufferingTimeLimit = TimeSpan.FromSeconds(1);
             options.BatchingOptions.QueueLimit = 10;
         })
         .CreateLogger();

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.204",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -16,7 +16,6 @@ using System.Net.Http;
 using Serilog.Configuration;
 using Serilog.Sinks.OpenTelemetry;
 using Serilog.Sinks.OpenTelemetry.Exporters;
-using Serilog.Sinks.PeriodicBatching;
 using Serilog.Collections;
 using Serilog.Core;
 using Serilog.Events;
@@ -63,9 +62,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
             resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
             includedData: options.IncludedData);
 
-        var sink = new PeriodicBatchingSink(openTelemetrySink, options.BatchingOptions);
-
-        return loggerSinkConfiguration.Sink(sink, options.RestrictedToMinimumLevel, options.LevelSwitch);
+        return loggerSinkConfiguration.Sink(openTelemetrySink, options.BatchingOptions, options.RestrictedToMinimumLevel, options.LevelSwitch);
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<Description>This Serilog sink transforms Serilog events into OpenTelemetry
 			logs and sends them to an OTLP (gRPC or HTTP) endpoint.</Description>
-		<VersionPrefix>2.0.1</VersionPrefix>
+		<VersionPrefix>3.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
 		<PackageTags>serilog;sink;opentelemetry</PackageTags>
@@ -14,6 +14,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<RootNamespace>Serilog</RootNamespace>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
@@ -25,11 +26,6 @@
 		<None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.1" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
-		<PackageReference Include="Serilog" Version="3.1.1" />
-		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
-	</ItemGroup>
-	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' ">
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+		<PackageReference Include="Serilog" Version="4.0.0-*" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
+++ b/src/Serilog.Sinks.OpenTelemetry/Serilog.Sinks.OpenTelemetry.csproj
@@ -24,8 +24,8 @@
 	<ItemGroup>
 		<None Include="../../assets/serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
 		<None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
-		<PackageReference Include="Google.Protobuf" Version="3.25.1" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.26.1" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.62.0" />
 		<PackageReference Include="Serilog" Version="4.0.0-*" />
 	</ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/BatchedOpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/BatchedOpenTelemetrySinkOptions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Serilog.Sinks.PeriodicBatching;
+using Serilog.Core.Sinks.Batching;
 
 namespace Serilog.Sinks.OpenTelemetry;
 
@@ -21,16 +21,16 @@ namespace Serilog.Sinks.OpenTelemetry;
 /// </summary>
 public class BatchedOpenTelemetrySinkOptions : OpenTelemetrySinkOptions
 {
-    const int DefaultBatchSizeLimit = 1000, DefaultPeriodSeconds = 2, DefaultQueueLimit = 100000;
+    const int DefaultBatchSizeLimit = 1000, DefaultBufferingTimeLimitSeconds = 2, DefaultQueueLimit = 100000;
 
     /// <summary>
     /// Options that control the sending of asynchronous log batches. When <c>null</c> a batch size of 1 is used.
     /// </summary>
-    public PeriodicBatchingSinkOptions BatchingOptions { get; } = new()
+    public BatchingOptions BatchingOptions { get; } = new()
     {
         EagerlyEmitFirstEvent = true,
         BatchSizeLimit = DefaultBatchSizeLimit,
-        Period = TimeSpan.FromSeconds(DefaultPeriodSeconds),
+        BufferingTimeLimit = TimeSpan.FromSeconds(DefaultBufferingTimeLimitSeconds),
         QueueLimit = DefaultQueueLimit
     };
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/BatchedOpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/BatchedOpenTelemetrySinkOptions.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Serilog.Core.Sinks.Batching;
+using Serilog.Configuration;
 
 namespace Serilog.Sinks.OpenTelemetry;
 

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Formatting/CleanMessageTemplateFormatter.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Formatting/CleanMessageTemplateFormatter.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
-
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using Serilog.Parsing;

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Formatting/Padding.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Formatting/Padding.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#nullable enable
-
 using Serilog.Parsing;
 
 namespace Serilog.Sinks.OpenTelemetry.Formatting

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Serilog Contributors
+﻿// Copyright © Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net.Http;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.OpenTelemetry.ProtocolHelpers;
-using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.OpenTelemetry;
 
@@ -59,7 +57,7 @@ class OpenTelemetrySink : IBatchedLogEventSink, ILogEventSink, IDisposable
     /// Transforms and sends the given batch of LogEvent objects
     /// to an OTLP endpoint.
     /// </summary>
-    public Task EmitBatchAsync(IEnumerable<LogEvent> batch)
+    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> batch)
     {
         var resourceLogs = _resourceLogsTemplate.Clone();
         

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -128,16 +128,14 @@ static class PrimitiveConversions
         
         foreach (var prop in value.Properties)
         {
-            if (!seen.Add(prop.Name))
-                continue;
-
-            var v = ToOpenTelemetryAnyValue(prop.Value);
-            var kv = new KeyValue
+            if (seen.Add(prop.Name))
             {
-                Key = prop.Name,
-                Value = v
-            };
-            kvList.Values.Add(kv);
+                kvList.Values.Add(new KeyValue
+                {
+                    Key = prop.Name,
+                    Value = ToOpenTelemetryAnyValue(prop.Value)
+                });
+            }
         }
 
         return map;

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -128,10 +128,8 @@ static class PrimitiveConversions
         
         foreach (var prop in value.Properties)
         {
-            if (seen.Contains(prop.Name))
+            if (!seen.Add(prop.Name))
                 continue;
-
-            seen.Add(prop.Name);
 
             var v = ToOpenTelemetryAnyValue(prop.Value);
             var kv = new KeyValue
@@ -145,7 +143,7 @@ static class PrimitiveConversions
         return map;
     }
 
-    public static AnyValue ToOpenTelemetryMap(DictionaryValue value)
+    static AnyValue ToOpenTelemetryMap(DictionaryValue value)
     {
         var map = new AnyValue();
         var kvList = new KeyValueList();

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetrySinkTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OpenTelemetrySinkTests.cs
@@ -48,7 +48,7 @@ public class OpenTelemetrySinkTests
         Assert.Single(resourceLogs.ScopeLogs.Single(r => r.Scope == null).LogRecords);
     }
 
-    static async Task<ExportLogsServiceRequest> ExportAsync(IEnumerable<LogEvent> events)
+    static async Task<ExportLogsServiceRequest> ExportAsync(IReadOnlyCollection<LogEvent> events)
     {
         var exporter = new CollectingExporter();
         var sink = new OpenTelemetrySink(exporter, null, new Dictionary<string, object>(), OpenTelemetrySinkOptions.DefaultIncludedData);

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.OpenTelemetry
     public class BatchedOpenTelemetrySinkOptions : Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions
     {
         public BatchedOpenTelemetrySinkOptions() { }
-        public Serilog.Sinks.PeriodicBatching.PeriodicBatchingSinkOptions BatchingOptions { get; }
+        public Serilog.Core.Sinks.Batching.BatchingOptions BatchingOptions { get; }
     }
     [System.Flags]
     public enum IncludedData

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.OpenTelemetry
     public class BatchedOpenTelemetrySinkOptions : Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions
     {
         public BatchedOpenTelemetrySinkOptions() { }
-        public Serilog.Core.Sinks.Batching.BatchingOptions BatchingOptions { get; }
+        public Serilog.Configuration.BatchingOptions BatchingOptions { get; }
     }
     [System.Flags]
     public enum IncludedData

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/Serilog.Sinks.OpenTelemetry.Tests.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="all" />
-    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="OpenTelemetry.SemanticConventions" Version="1.0.0-rc9.9" />


### PR DESCRIPTION
This includes a small **breaking change**: the type of `options.BatchingOptions` changes from a _Serilog.Sinks.PeriodicBatching_ type, to a _Serilog_ type. These are structurally identical apart from `Period`, which has been renamed to `BufferingTimeLimit`.

Draft until https://github.com/serilog/serilog/pull/2058 is addressed.