### PR TITLE
Use the `OTEL_SERVICE_NAME` variable when present

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Configuration/OpenTelemetryEnvironment.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Configuration/OpenTelemetryEnvironment.cs
@@ -20,6 +20,7 @@ static class OpenTelemetryEnvironment
     const string EndpointVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
     const string HeaderVarName = "OTEL_EXPORTER_OTLP_HEADERS";
     const string ResourceAttributesVarName = "OTEL_RESOURCE_ATTRIBUTES";
+    const string ServiceNameVarName = "OTEL_SERVICE_NAME";
 
     public static void Configure(BatchedOpenTelemetrySinkOptions options, Func<string, string?> getEnvironmentVariable)
     {
@@ -39,6 +40,11 @@ static class OpenTelemetryEnvironment
         FillHeadersIfPresent(getEnvironmentVariable(HeaderVarName), options.Headers);
 
         FillHeadersResourceAttributesIfPresent(getEnvironmentVariable(ResourceAttributesVarName), options.ResourceAttributes);
+
+        if (getEnvironmentVariable(ServiceNameVarName) is { Length: > 1 } serviceName)
+        {
+            options.ResourceAttributes[SemanticConventions.AttributeServiceName] = serviceName;
+        }
     }
 
     static void FillHeadersIfPresent(string? config, IDictionary<string, string> headers)


### PR DESCRIPTION
This is used by .NET Aspire; called out in https://github.com/serilog/serilog-aspnetcore/issues/359#issuecomment-2228829009

`OTEL_SERVICE_NAME` is documented at https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration

> Sets the value of the [service.name](https://opentelemetry.io/docs/specs/semconv/resource/#service) resource attribute
> 
> If service.name is also provided in OTEL_RESOURCE_ATTRIBUTES, then OTEL_SERVICE_NAME takes precedence.