### PR TITLE
Allow configuring OTEL_ values from any source

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -54,14 +54,36 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         Action<BatchedOpenTelemetrySinkOptions> configure,
         bool ignoreEnvironment = false)
     {
+        if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
+
+        return loggerSinkConfiguration.OpenTelemetry(
+            configure,
+            ignoreEnvironment ? null : Environment.GetEnvironmentVariable
+        );
+    }
+
+    /// <summary>
+    /// Send log events to an OTLP exporter.
+    /// </summary>
+    /// <param name="loggerSinkConfiguration">
+    /// The `WriteTo` configuration object.
+    /// </param>
+    /// <param name="configure">The configuration callback.</param>
+    /// <param name="getConfigurationVariable">Provides <see href="https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/">OTLP Exporter
+    /// Configuration options</see> that will override values in configuration</param>
+    public static LoggerConfiguration OpenTelemetry(
+        this LoggerSinkConfiguration loggerSinkConfiguration,
+        Action<BatchedOpenTelemetrySinkOptions> configure,
+        Func<string, string?>? getConfigurationVariable)
+    {
         if (configure == null) throw new ArgumentNullException(nameof(configure));
 
         var options = new BatchedOpenTelemetrySinkOptions();
         configure(options);
 
-        if (!ignoreEnvironment)
+        if (getConfigurationVariable != null)
         {
-            OpenTelemetryEnvironment.Configure(options, Environment.GetEnvironmentVariable);
+            OpenTelemetryEnvironment.Configure(options, getConfigurationVariable);
         }
 
         var exporter = Exporter.Create(

--- a/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -54,8 +54,6 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         Action<BatchedOpenTelemetrySinkOptions> configure,
         bool ignoreEnvironment = false)
     {
-        if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
-
         return loggerSinkConfiguration.OpenTelemetry(
             configure,
             ignoreEnvironment ? null : Environment.GetEnvironmentVariable
@@ -70,12 +68,13 @@ public static class OpenTelemetryLoggerConfigurationExtensions
     /// </param>
     /// <param name="configure">The configuration callback.</param>
     /// <param name="getConfigurationVariable">Provides <see href="https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/">OTLP Exporter
-    /// Configuration options</see> that will override values in configuration</param>
+    /// Configuration variables</see> that will override other options when present.</param>
     public static LoggerConfiguration OpenTelemetry(
         this LoggerSinkConfiguration loggerSinkConfiguration,
         Action<BatchedOpenTelemetrySinkOptions> configure,
         Func<string, string?>? getConfigurationVariable)
     {
+        if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
         if (configure == null) throw new ArgumentNullException(nameof(configure));
 
         var options = new BatchedOpenTelemetrySinkOptions();

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Configuration/OpenTelemetryEnvironment.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/Configuration/OpenTelemetryEnvironment.cs
@@ -22,23 +22,23 @@ static class OpenTelemetryEnvironment
     const string ResourceAttributesVarName = "OTEL_RESOURCE_ATTRIBUTES";
     const string ServiceNameVarName = "OTEL_SERVICE_NAME";
 
-    public static void Configure(BatchedOpenTelemetrySinkOptions options, Func<string, string?> getEnvironmentVariable)
+    public static void Configure(BatchedOpenTelemetrySinkOptions options, Func<string, string?> getConfigurationVariable)
     {
-        options.Protocol = getEnvironmentVariable(ProtocolVarName) switch
+        options.Protocol = getConfigurationVariable(ProtocolVarName) switch
         {
             "http/protobuf" => OtlpProtocol.HttpProtobuf,
             "grpc" => OtlpProtocol.Grpc,
             _ => options.Protocol
         };
 
-        if (getEnvironmentVariable(EndpointVarName) is { Length: > 1 } endpoint)
+        if (getConfigurationVariable(EndpointVarName) is { Length: > 1 } endpoint)
             options.Endpoint = endpoint;
 
-        FillHeadersIfPresent(getEnvironmentVariable(HeaderVarName), options.Headers);
+        FillHeadersIfPresent(getConfigurationVariable(HeaderVarName), options.Headers);
 
-        FillHeadersResourceAttributesIfPresent(getEnvironmentVariable(ResourceAttributesVarName), options.ResourceAttributes);
+        FillHeadersResourceAttributesIfPresent(getConfigurationVariable(ResourceAttributesVarName), options.ResourceAttributes);
 
-        if (getEnvironmentVariable(ServiceNameVarName) is { Length: > 1 } serviceName)
+        if (getConfigurationVariable(ServiceNameVarName) is { Length: > 1 } serviceName)
         {
             options.ResourceAttributes[SemanticConventions.AttributeServiceName] = serviceName;
         }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -1,9 +1,10 @@
-﻿namespace Serilog
+namespace Serilog
 {
     public static class OpenTelemetryLoggerConfigurationExtensions
     {
         public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerAuditSinkConfiguration loggerAuditSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.OpenTelemetrySinkOptions> configure) { }
         public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.BatchedOpenTelemetrySinkOptions> configure, bool ignoreEnvironment = false) { }
+        public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, System.Action<Serilog.Sinks.OpenTelemetry.BatchedOpenTelemetrySinkOptions> configure, System.Func<string, string?>? getConfigurationVariable) { }
         public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerAuditSinkConfiguration loggerAuditSinkConfiguration, string endpoint = "http://localhost:4317", Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0, System.Collections.Generic.IDictionary<string, string>? headers = null, System.Collections.Generic.IDictionary<string, object>? resourceAttributes = null, Serilog.Sinks.OpenTelemetry.IncludedData? includedData = default) { }
         public static Serilog.LoggerConfiguration OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, string endpoint = "http://localhost:4317", Serilog.Sinks.OpenTelemetry.OtlpProtocol protocol = 0, System.Collections.Generic.IDictionary<string, string>? headers = null, System.Collections.Generic.IDictionary<string, object>? resourceAttributes = null, Serilog.Sinks.OpenTelemetry.IncludedData? includedData = default, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, Serilog.Core.LoggingLevelSwitch? levelSwitch = null) { }
     }


### PR DESCRIPTION
This fixes #151 by exposing already existing configuration delegate.

I thought about adding some tests, but there's no good seam to verify the behavior and the code is as simple as it could be.