### PR TITLE
Remove redundant `/v1/logs` path from endpoints in README and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ setups, and looks like:
 ```csharp
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(
-        endpoint: "http://127.0.0.1:4318/v1/logs",
+        endpoint: "http://127.0.0.1:4318",
         protocol: OtlpProtocol.HttpProtobuf)
     .CreateLogger();
 ```
@@ -57,7 +57,7 @@ configuration, which looks like:
 Log.Logger = new LoggerConfiguration()
     .WriteTo.OpenTelemetry(options =>
     {
-        options.Endpoint = "http://127.0.0.1:4318/v1/logs";
+        options.Endpoint = "http://127.0.0.1:4318";
         options.Protocol = OtlpProtocol.HttpProtobuf;
     })
     .CreateLogger();

--- a/example/Example/Program.cs
+++ b/example/Example/Program.cs
@@ -63,7 +63,7 @@ static void SendLogs(ILogger logger, string protocol)
 static Logger CreateLogger(OtlpProtocol protocol)
 {
     var endpoint = protocol == OtlpProtocol.HttpProtobuf ?
-        "http://localhost:4318/v1/logs" :
+        "http://localhost:4318" :
         "http://localhost:4317";
 
     return new LoggerConfiguration()


### PR DESCRIPTION
This isn't needed anymore in v4 of the sink (although it's still accepted).