### PR TITLE
Add an option to include `StructureValue.TypeTag` as `$type` when converting to OTLP maps

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "9.0.200",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Diagnostics;
+using OpenTelemetry.Proto.Common.V1;
+using Serilog.Events;
 
 namespace Serilog.Sinks.OpenTelemetry;
 
@@ -82,5 +84,11 @@ public enum IncludedData
     /// Preserve the value of the <c>SourceContext</c> property, in addition to using it as the OTLP <c>InstrumentationScope</c> name. If
     /// not specified, the <c>SourceContext</c> property will be omitted from the individual log record attributes.
     /// </summary>
-    SourceContextAttribute = 128
+    SourceContextAttribute = 128,
+    
+    /// <summary>
+    /// Include <see cref="StructureValue.TypeTag"/> as <c>$type</c> when converting event properties to
+    /// OTLP <see cref="AnyValue.KvlistValue"/> values.
+    /// </summary>
+    StructureValueTypeTags = 256,
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
@@ -120,7 +120,7 @@ static class OtlpEventBuilder
                 continue;
             }
 
-            var v = PrimitiveConversions.ToOpenTelemetryAnyValue(property.Value);
+            var v = PrimitiveConversions.ToOpenTelemetryAnyValue(property.Value, includedData);
             addAttribute(PrimitiveConversions.NewAttribute(property.Key, v));
         }
     }

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -28,6 +28,7 @@ namespace Serilog.Sinks.OpenTelemetry
         TemplateBody = 32,
         MessageTemplateRenderingsAttribute = 64,
         SourceContextAttribute = 128,
+        StructureValueTypeTags = 256,
     }
     public class OpenTelemetrySinkOptions
     {


### PR DESCRIPTION
Some structured data is hard to interpret without `$type`. I've left this as an opt-in since for some consumers it will be just noise, but in future we might want to add this to the default set.