### PR TITLE
Add short exception type handling to logging

### DIFF
--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/IncludedData.cs
@@ -91,4 +91,9 @@ public enum IncludedData
     /// OTLP <see cref="AnyValue.KvlistValue"/> values.
     /// </summary>
     StructureValueTypeTags = 256,
+    
+    /// <summary>
+    /// Include the short (unqualified) name of the exception type in the <c>exception.type</c> attribute when an exception is logged.
+    /// </summary>
+    ShortExceptionType = 512,
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -170,4 +170,14 @@ public class OpenTelemetrySinkOptions
     /// <remarks>This callback accepts a <c langword="bool"/> in order to match the signature of the OpenTelemetry SDK method
     /// that is typically assigned to it. The sink always provides the callback with the value <c langword="true" />.</remarks>
     public Func<bool, IDisposable>? OnBeginSuppressInstrumentation { get; set; }
+
+
+    /// <summary>
+    /// Enables short name exception for the property <c>exception.type</c>.
+    /// When an exception is logged, the default value is <c>false</c>.
+    /// If set to <c>true</c>, the sink will use the short name of the exception type.
+    /// For example, if the exception type is <c>System.ArgumentNullException</c>,
+    /// the value of the property <c>exception.type</c> will be <c>ArgumentNullException</c>.
+    /// </summary>
+    public bool ShortNameException { get; set; } = false;
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -170,14 +170,4 @@ public class OpenTelemetrySinkOptions
     /// <remarks>This callback accepts a <c langword="bool"/> in order to match the signature of the OpenTelemetry SDK method
     /// that is typically assigned to it. The sink always provides the callback with the value <c langword="true" />.</remarks>
     public Func<bool, IDisposable>? OnBeginSuppressInstrumentation { get; set; }
-
-
-    /// <summary>
-    /// Enables short name exception for the property <c>exception.type</c>.
-    /// When an exception is logged, the default value is <c>false</c>.
-    /// If set to <c>true</c>, the sink will use the short name of the exception type.
-    /// For example, if the exception type is <c>System.ArgumentNullException</c>,
-    /// the value of the property <c>exception.type</c> will be <c>ArgumentNullException</c>.
-    /// </summary>
-    public bool ShortNameException { get; set; } = false;
 }

--- a/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
+++ b/src/Serilog.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
@@ -38,7 +38,7 @@ static class OtlpEventBuilder
         ProcessTimestamp(logRecord, logEvent);
         ProcessBody(logRecord, logEvent, includedData, formatProvider);
         ProcessLevel(logRecord, logEvent);
-        ProcessException(logRecord.Attributes, logEvent);
+        ProcessException(logRecord.Attributes, logEvent, includedData);
         ProcessIncludedFields(logRecord, logEvent, includedData);
 
         return (logRecord, scopeName);
@@ -53,7 +53,7 @@ static class OtlpEventBuilder
         ProcessStartTime(span, logEvent);
         ProcessName(span, logEvent);
         ProcessLevel(span, logEvent);
-        ProcessException(span.Attributes, logEvent);
+        ProcessException(span.Attributes, logEvent, includedData);
         ProcessIncludedFields(span, logEvent, includedData);
         ProcessParentSpanId(span, logEvent);
         ProcessKind(span, logEvent);
@@ -156,12 +156,15 @@ static class OtlpEventBuilder
         span.Kind = PrimitiveConversions.ToOpenTelemetrySpanKind(kind);
     }
 
-    public static void ProcessException(RepeatedField<KeyValue> attrs, LogEvent logEvent)
+    public static void ProcessException(RepeatedField<KeyValue> attrs, LogEvent logEvent, IncludedData includedFields)
     {
         var ex = logEvent.Exception;
         if (ex != null)
         {
-            attrs.Add(PrimitiveConversions.NewStringAttribute(SemanticConventions.AttributeExceptionType, ex.GetType().ToString()));
+            var exceptionType = ((includedFields & IncludedData.ShortExceptionType) == IncludedData.ShortExceptionType)
+                ? ex.GetType().Name
+                : ex.GetType().ToString();
+            attrs.Add(PrimitiveConversions.NewStringAttribute(SemanticConventions.AttributeExceptionType, exceptionType));                        
 
             if (ex.Message != "")
             {

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
@@ -99,9 +99,41 @@ public class OtlpEventBuilderTests
             var logRecord = new LogRecord();
             var logEvent = Some.SerilogEvent(Some.TestMessageTemplate, ex: ex);
 
-            OtlpEventBuilder.ProcessException(logRecord.Attributes, logEvent);
+            OtlpEventBuilder.ProcessException(logRecord.Attributes, logEvent, IncludedData.None);
 
             var typeKeyValue = PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionType, error.GetType().ToString());
+            var messageKeyValue = PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionMessage, error.Message);
+
+            Assert.Equal(3, logRecord.Attributes.Count);
+            Assert.NotEqual(-1, logRecord.Attributes.IndexOf(typeKeyValue));
+            Assert.NotEqual(-1, logRecord.Attributes.IndexOf(messageKeyValue));
+
+            Assert.NotNull(ex.StackTrace);
+            if (ex.StackTrace != null)
+            {
+                var traceKeyValue = PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionStacktrace, ex.ToString());
+                Assert.NotEqual(-1, logRecord.Attributes.IndexOf(traceKeyValue));
+            }
+        }
+    }
+
+    [Fact]
+    public void TestExceptionWithShortName()
+    {
+        var error = new Exception("error_message");
+
+        try
+        {
+            throw error;
+        }
+        catch (Exception ex)
+        {
+            var logRecord = new LogRecord();
+            var logEvent = Some.SerilogEvent(Some.TestMessageTemplate, ex: ex);
+
+            OtlpEventBuilder.ProcessException(logRecord.Attributes, logEvent, IncludedData.ShortExceptionType);
+
+            var typeKeyValue = PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionType, error.GetType().Name.ToString());
             var messageKeyValue = PrimitiveConversions.NewStringAttribute(TraceSemanticConventions.AttributeExceptionMessage, error.Message);
 
             Assert.Equal(3, logRecord.Attributes.Count);

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -45,7 +45,6 @@ namespace Serilog.Sinks.OpenTelemetry
         public Serilog.Sinks.OpenTelemetry.OtlpProtocol Protocol { get; set; }
         public System.Collections.Generic.IDictionary<string, object> ResourceAttributes { get; set; }
         public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
-        public bool ShortNameException { get; set; }
         public string? TracesEndpoint { get; set; }
     }
     public enum OtlpProtocol

--- a/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
+++ b/test/Serilog.Sinks.OpenTelemetry.Tests/PublicApiVisibilityTests.approved.txt
@@ -29,6 +29,7 @@ namespace Serilog.Sinks.OpenTelemetry
         MessageTemplateRenderingsAttribute = 64,
         SourceContextAttribute = 128,
         StructureValueTypeTags = 256,
+        ShortExceptionType = 512,
     }
     public class OpenTelemetrySinkOptions
     {
@@ -44,6 +45,7 @@ namespace Serilog.Sinks.OpenTelemetry
         public Serilog.Sinks.OpenTelemetry.OtlpProtocol Protocol { get; set; }
         public System.Collections.Generic.IDictionary<string, object> ResourceAttributes { get; set; }
         public Serilog.Events.LogEventLevel RestrictedToMinimumLevel { get; set; }
+        public bool ShortNameException { get; set; }
         public string? TracesEndpoint { get; set; }
     }
     public enum OtlpProtocol


### PR DESCRIPTION
# Note
I have used the short exception type in many of our company dashboards and found that by default, this sink uses the fully qualified namespace like `System.Exception` instead of `Exception`. As a result, we need to update our dashboards for many teams.

This small change will make a big difference for us.

# Changes
- Introduced the `ShortExceptionType` enum value in `IncludedData` for logging short exception names.
- Added the `ShortNameException` property in `OpenTelemetrySinkOptions` to control short name usage.
- Updated the `ProcessException` method to accept `IncludedData` for flexible exception type logging.
- Modified relevant calls to `ProcessException` in `OtlpEventBuilder`.
- Added `TestExceptionWithShortName` to validate short name logging in tests.
- Updated `PublicApiVisibilityTests.approved.txt` to include the new enum and property.